### PR TITLE
cleaning up import style

### DIFF
--- a/src/herbpy/tsr/block.py
+++ b/src/herbpy/tsr/block.py
@@ -1,8 +1,7 @@
 import numpy
-from prpy.tsr.tsrlibrary import TSRFactory
-from prpy.tsr.tsr import *
+import prpy.tsr 
 
-@TSRFactory('herb', 'block', 'place')
+@prpy.tsr.tsrlibrary.TSRFactory('herb', 'block', 'place')
 def block_at_pose(robot, block, position, manip=None):
     '''
     Generates end-effector poses for placing the block on another object
@@ -29,19 +28,19 @@ def block_at_pose(robot, block, position, manip=None):
     Bw = numpy.zeros((6,2))
     Bw[5,:] = [-numpy.pi, numpy.pi]
 
-    place_tsr = TSR(T0_w = T0_w,
-                    Tw_e = numpy.eye(4),
-                    Bw = Bw,
-                    manip = manip_idx)
+    place_tsr = prpy.tsr.TSR(T0_w = T0_w,
+                             Tw_e = numpy.eye(4),
+                             Bw = Bw,
+                             manip = manip_idx)
 
     ee_in_block = numpy.dot(numpy.linalg.inv(block.GetTransform()), manip.GetEndEffectorTransform())
-    ee_tsr = TSR(T0_w = numpy.eye(4), #ignored
-                 Tw_e = ee_in_block,
-                 Bw = numpy.zeros((6,2)),
-                 manip = manip_idx)
+    ee_tsr = prpy.tsr.TSR(T0_w = numpy.eye(4), #ignored
+                          Tw_e = ee_in_block,
+                          Bw = numpy.zeros((6,2)),
+                          manip = manip_idx)
 
-    place_tsr_chain = TSRChain(sample_start=False, 
-                               sample_goal = True,
-                               TSRs = [place_tsr, ee_tsr])
+    place_tsr_chain = prpy.tsr.TSRChain(sample_start=False, 
+                                        sample_goal = True,
+                                        TSRs = [place_tsr, ee_tsr])
     return [place_tsr_chain]
         

--- a/src/herbpy/tsr/bowl.py
+++ b/src/herbpy/tsr/bowl.py
@@ -1,8 +1,7 @@
 import numpy
-from prpy.tsr.tsrlibrary import TSRFactory
-from prpy.tsr.tsr import *
+import prpy.tsr
 
-@TSRFactory('herb', 'plastic_bowl', 'grasp')
+@prpy.tsr.tsrlibrary.TSRFactory('herb', 'plastic_bowl', 'grasp')
 def bowl_grasp(robot, bowl, manip=None):
     '''
     @param robot The robot performing the grasp
@@ -26,12 +25,13 @@ def bowl_grasp(robot, bowl, manip=None):
     Bw[2,:] = [-0.02, 0.02] # Allow a little verticle movement
     Bw[5,:] = [-numpy.pi, numpy.pi] # Allow any orientation
 
-    grasp_tsr = TSR(T0_w = T0_w, Tw_e = Tw_e, Bw = Bw, manip = manip_idx)
-    grasp_chain = TSRChain(sample_start=False, sample_goal = True, constrain=False, TSR = grasp_tsr)
+    grasp_tsr = prpy.tsr.TSR(T0_w = T0_w, Tw_e = Tw_e, Bw = Bw, manip = manip_idx)
+    grasp_chain = prpy.tsr.TSRChain(sample_start=False, sample_goal = True, 
+                                    constrain=False, TSR = grasp_tsr)
 
     return [grasp_chain]
     
-@TSRFactory('herb', 'plastic_bowl', 'place')
+@prpy.tsr.tsrlibrary.TSRFactory('herb', 'plastic_bowl', 'place')
 def bowl_on_table(robot, bowl, pose_tsr_chain, manip=None):
     '''
     Generates end-effector poses for placing the bowl on the table.
@@ -59,9 +59,9 @@ def bowl_on_table(robot, bowl, pose_tsr_chain, manip=None):
         if tsr.manipindex != manip_idx:
             raise Exception('pose_tsr_chain defined for a different manipulator.')
 
-    grasp_tsr = TSR(Tw_e = ee_in_bowl, Bw = Bw, manip = manip_idx)
+    grasp_tsr = prpy.tsr.TSR(Tw_e = ee_in_bowl, Bw = Bw, manip = manip_idx)
     all_tsrs = list(pose_tsr_chain.TSRs) + [grasp_tsr]
-    place_chain = TSRChain(sample_start = False, sample_goal = True, constrain = False,
+    place_chain = prpy.tsr.TSRChain(sample_start = False, sample_goal = True, constrain = False,
                            TSRs = all_tsrs)
 
     return  [ place_chain ]

--- a/src/herbpy/tsr/glass.py
+++ b/src/herbpy/tsr/glass.py
@@ -1,8 +1,7 @@
 import numpy
-from prpy.tsr.tsrlibrary import TSRFactory
-from prpy.tsr.tsr import *
+import prpy.tsr
 
-@TSRFactory('herb', 'plastic_glass', 'grasp')
+@prpy.tsr.tsrlibrary.TSRFactory('herb', 'plastic_glass', 'grasp')
 def glass_grasp(robot, glass, manip=None):
     '''
     @param robot The robot performing the grasp
@@ -27,12 +26,13 @@ def glass_grasp(robot, glass, manip=None):
     Bw[2,:] = [0.0, 0.02]  # Allow a little vertical movement
     Bw[5,:] = [-numpy.pi, numpy.pi]  # Allow any orientation
     
-    grasp_tsr = TSR(T0_w = T0_w, Tw_e = Tw_e, Bw = Bw, manip = manip_idx)
-    grasp_chain = TSRChain(sample_start=False, sample_goal = True, constrain=False, TSR = grasp_tsr)
+    grasp_tsr = prpy.tsr.TSR(T0_w = T0_w, Tw_e = Tw_e, Bw = Bw, manip = manip_idx)
+    grasp_chain = prpy.tsr.TSRChain(sample_start=False, sample_goal = True, 
+                                    constrain=False, TSR = grasp_tsr)
 
     return [grasp_chain]
 
-@TSRFactory('herb', 'plastic_glass', 'push_grasp')
+@prpy.tsr.tsrlibrary.TSRFactory('herb', 'plastic_glass', 'push_grasp')
 def glass_push_grasp(robot, glass, manip=None):
     '''
     This factory differes from glass_grasp in that it places the manipulator 
@@ -65,12 +65,13 @@ def glass_push_grasp(robot, glass, manip=None):
     Bw[2,:] = [-0.02, 0.02]  # Allow a little vertical movement
     Bw[5,:] = [-numpy.pi, numpy.pi]  # Allow any orientation
     
-    grasp_tsr = TSR(T0_w = T0_w, Tw_e = Tw_e, Bw = Bw, manip = manip_idx)
-    grasp_chain = TSRChain(sample_start=False, sample_goal = True, constrain=False, TSR = grasp_tsr)
+    grasp_tsr = prpy.tsr.TSR(T0_w = T0_w, Tw_e = Tw_e, Bw = Bw, manip = manip_idx)
+    grasp_chain = prpy.tsr.TSRChain(sample_start=False, sample_goal = True, 
+                                    constrain=False, TSR = grasp_tsr)
 
     return [grasp_chain]
                 
-@TSRFactory('herb', 'plastic_glass', 'place')
+@prpy.tsr.tsrlibrary.TSRFactory('herb', 'plastic_glass', 'place')
 def glass_on_table(robot, glass, pose_tsr_chain, manip=None):
     '''
     Generates end-effector poses for placing the glass on the table.
@@ -98,14 +99,14 @@ def glass_on_table(robot, glass, pose_tsr_chain, manip=None):
         if tsr.manipindex != manip_idx:
             raise Exception('pose_tsr_chain defined for a different manipulator.')
 
-    grasp_tsr = TSR(Tw_e = ee_in_glass, Bw = Bw, manip = manip_idx)
+    grasp_tsr = prpy.tsr.TSR(Tw_e = ee_in_glass, Bw = Bw, manip = manip_idx)
     all_tsrs = list(pose_tsr_chain.TSRs) + [grasp_tsr]
-    place_chain = TSRChain(sample_start = False, sample_goal = True, constrain = False,
+    place_chain = prpy.tsr.TSRChain(sample_start = False, sample_goal = True, constrain = False,
                            TSRs = all_tsrs)
 
     return  [ place_chain ]
     
-@TSRFactory('herb', 'plastic_glass', 'transport')
+@prpy.tsr.tsrlibrary.TSRFactory('herb', 'plastic_glass', 'transport')
 def glass_transport(robot, glass, manip=None, roll_epsilon=0.2, pitch_epsilon=0.2, yaw_epsilon=0.2):
     '''
     Generates a trajectory-wide constraint for transporting the object with little roll, pitch or yaw
@@ -136,11 +137,11 @@ def glass_transport(robot, glass, manip=None, roll_epsilon=0.2, pitch_epsilon=0.
                       [-roll_epsilon, roll_epsilon],
                       [-pitch_epsilon, pitch_epsilon],
                       [-yaw_epsilon, yaw_epsilon]])
-    transport_tsr = TSR(T0_w = glass.GetTransform(),
-                        Tw_e = ee_in_glass,
-                        Bw = Bw,
-                        manip = manip_idx)
-    transport_chain = TSRChain(sample_start = False, sample_goal=False, constrain=True,
-                               TSR = transport_tsr)
+    transport_tsr = prpy.tsr.TSR(T0_w = glass.GetTransform(),
+                                 Tw_e = ee_in_glass,
+                                 Bw = Bw,
+                                 manip = manip_idx)
+    transport_chain = prpy.tsr.TSRChain(sample_start = False, sample_goal=False, constrain=True,
+                                        TSR = transport_tsr)
     
     return [ transport_chain ]

--- a/src/herbpy/tsr/pitcher.py
+++ b/src/herbpy/tsr/pitcher.py
@@ -1,8 +1,7 @@
 import numpy
-from prpy.tsr.tsrlibrary import TSRFactory
-from prpy.tsr.tsr import *
+import prpy.tsr
 
-@TSRFactory('herb', 'rubbermaid_ice_guard_pitcher', 'grasp')
+@prpy.tsr.tsrlibrary.TSRFactory('herb', 'rubbermaid_ice_guard_pitcher', 'grasp')
 def pitcher_grasp(robot, pitcher, manip=None):
     '''
     @param robot The robot performing the grasp
@@ -26,12 +25,13 @@ def pitcher_grasp(robot, pitcher, manip=None):
     Bw = numpy.zeros((6,2))
     Bw[2,:] = [-0.01, 0.01]  # Allow a little vertical movement
     
-    grasp_tsr = TSR(T0_w = T0_w, Tw_e = Tw_e, Bw = Bw, manip = manip_idx)
-    grasp_chain = TSRChain(sample_start=False, sample_goal = True, constrain=False, TSR = grasp_tsr)
+    grasp_tsr = prpy.tsr.TSR(T0_w = T0_w, Tw_e = Tw_e, Bw = Bw, manip = manip_idx)
+    grasp_chain = prpy.tsr.TSRChain(sample_start=False, sample_goal = True, 
+                                    constrain=False, TSR = grasp_tsr)
 
     return [grasp_chain]
         
-@TSRFactory('herb', 'rubbermaid_ice_guard_pitcher', 'pour')
+@prpy.tsr.tsrlibrary.TSRFactory('herb', 'rubbermaid_ice_guard_pitcher', 'pour')
 def pitcher_pour(robot, pitcher, min_tilt = 1.4, max_tilt = 1.57, manip=None, grasp_transform = None, 
                  pitcher_pose = None):
     '''
@@ -71,29 +71,29 @@ def pitcher_pour(robot, pitcher, min_tilt = 1.4, max_tilt = 1.57, manip=None, gr
     Bw_pour = numpy.zeros((6,2))
     Bw_pour[4,:] = [ -0.2, 1.57 ]
         
-    tsr_0 = TSR(T0_w = pitcher_pose,
-                Tw_e = spout_in_pitcher,
-                Bw = numpy.zeros((6,2)),
-                manip = manip_idx)
+    tsr_0 = prpy.tsr.TSR(T0_w = pitcher_pose,
+                         Tw_e = spout_in_pitcher,
+                         Bw = numpy.zeros((6,2)),
+                         manip = manip_idx)
 
-    tsr_1_constraint = TSR(Tw_e = ee_in_spout,
-                           Bw = Bw_pour,
-                           manip = manip_idx)
+    tsr_1_constraint = prpy.tsr.TSR(Tw_e = ee_in_spout,
+                                    Bw = Bw_pour,
+                                    manip = manip_idx)
 
-    pour_chain = TSRChain(sample_start = False,
-                          sample_goal = False,
-                          constrain = True,
-                          TSRs = [tsr_0, tsr_1_constraint])
+    pour_chain = prpy.tsr.TSRChain(sample_start = False,
+                                   sample_goal = False,
+                                   constrain = True,
+                                   TSRs = [tsr_0, tsr_1_constraint])
 
     Bw_goal = numpy.zeros((6,2))
     Bw_goal[4,:] = [ min_tilt, max_tilt ]
-    tsr_1_goal = TSR(Tw_e = ee_in_spout,
-                     Bw = Bw_goal,
-                     manip = manip_idx)
-    pour_goal = TSRChain(sample_start = False,
-                         sample_goal = True,
-                         constrain = False,
-                         TSRs = [tsr_0, tsr_1_goal])
+    tsr_1_goal = prpy.tsr.TSR(Tw_e = ee_in_spout,
+                              Bw = Bw_goal,
+                              manip = manip_idx)
+    pour_goal = prpy.tsr.TSRChain(sample_start = False,
+                                  sample_goal = True,
+                                  constrain = False,
+                                  TSRs = [tsr_0, tsr_1_goal])
 
     return [pour_chain, pour_goal]
                     

--- a/src/herbpy/tsr/plate.py
+++ b/src/herbpy/tsr/plate.py
@@ -1,8 +1,7 @@
 import numpy
-from prpy.tsr.tsrlibrary import TSRFactory
-from prpy.tsr.tsr import *
+import prpy.tsr
 
-@TSRFactory('herb', 'plastic_plate', 'grasp')
+@prpy.tsr.tsrlibrary.TSRFactory('herb', 'plastic_plate', 'grasp')
 def plate_grasp(robot, plate, manip=None):
     '''
     @param robot The robot performing the grasp
@@ -27,12 +26,13 @@ def plate_grasp(robot, plate, manip=None):
     Bw[2,:] = [0.0, 0.01] # Allow a little verticle movement
     Bw[5,:] = [-numpy.pi, numpy.pi] # Allow any point around the edge of the plate
 
-    grasp_tsr = TSR(T0_w = T0_w, Tw_e = Tw_e, Bw = Bw, manip = manip_idx)
-    grasp_chain = TSRChain(sample_start=False, sample_goal = True, constrain=False, TSR = grasp_tsr)
+    grasp_tsr = prpy.tsr.TSR(T0_w = T0_w, Tw_e = Tw_e, Bw = Bw, manip = manip_idx)
+    grasp_chain = prpy.tsr.TSRChain(sample_start=False, sample_goal = True, 
+                                    constrain=False, TSR = grasp_tsr)
 
     return [grasp_chain]
     
-@TSRFactory('herb', 'plastic_plate', 'place')
+@prpy.tsr.tsrlibrary.TSRFactory('herb', 'plastic_plate', 'place')
 def plate_on_table(robot, plate, pose_tsr_chain, manip=None):
     '''
     Generates end-effector poses for placing the plate on the table.
@@ -87,10 +87,10 @@ def plate_on_table(robot, plate, pose_tsr_chain, manip=None):
     #plate_tsr = TSR(Tw_e = tilted_plate_in_table, Bw = numpy.zeros((6,2)), manip = manip_idx)
     plate_in_table = numpy.eye(4)
     plate_in_table[2,3] = 0.20
-    plate_tsr = TSR(Tw_e = plate_in_table, Bw = numpy.zeros((6,2)), manip = manip_idx)
-    grasp_tsr = TSR(Tw_e = ee_in_plate, Bw = Bw, manip = manip_idx)
+    plate_tsr = prpy.tsr.TSR(Tw_e = plate_in_table, Bw = numpy.zeros((6,2)), manip = manip_idx)
+    grasp_tsr = prpy.tsr.TSR(Tw_e = ee_in_plate, Bw = Bw, manip = manip_idx)
     all_tsrs = list(pose_tsr_chain.TSRs) + [plate_tsr, grasp_tsr]
-    place_chain = TSRChain(sample_start = False, sample_goal = True, constrain = False,
+    place_chain = prpy.tsr.TSRChain(sample_start = False, sample_goal = True, constrain = False,
                            TSRs = all_tsrs)
 
     return  [ place_chain ]

--- a/src/herbpy/tsr/table.py
+++ b/src/herbpy/tsr/table.py
@@ -1,8 +1,7 @@
 import numpy
-from prpy.tsr.tsrlibrary import TSRFactory
-from prpy.tsr.tsr import *
+import prpy.tsr
 
-@TSRFactory('herb', 'conference_table', 'point_on')
+@prpy.tsr.tsrlibrary.TSRFactory('herb', 'conference_table', 'point_on')
 def point_on(robot, table, manip=None):
     '''
     This creates a TSR that allows you to sample poses on the table.
@@ -34,7 +33,7 @@ def point_on(robot, table, manip=None):
     Bw[2,:] = [-0.38, 0.38]
     Bw[4,:] = [-numpy.pi, numpy.pi] # allow any rotation around y - which is the axis normal to the table top
     
-    table_top_tsr = TSR(T0_w = T0_w, Tw_e = Tw_e, Bw = Bw, manip = manip_idx)
-    table_top_chain = TSRChain(sample_start = False, sample_goal = True, constrain=False, 
+    table_top_tsr = prpy.tsr.TSR(T0_w = T0_w, Tw_e = Tw_e, Bw = Bw, manip = manip_idx)
+    table_top_chain = prpy.tsr.TSRChain(sample_start = False, sample_goal = True, constrain=False, 
                                TSR = table_top_tsr)
     return [table_top_chain]


### PR DESCRIPTION
Since (as mentioned when doing fuze.py) the preferred method is to explicitly list libraries instead of using "from prpy.tsr.tsr import *" or "from prpy.tsr.tsrlibrary import TSRFactory" I made that correction across the rest of the library. 