### PR TITLE
Bugfix/tsr locking cleanup

### DIFF
--- a/src/herbpy/action/blocks.py
+++ b/src/herbpy/action/blocks.py
@@ -36,10 +36,11 @@ def _GrabBlock(robot, blocks, table, manip=None, preshape=None,
     manip.hand.MoveHand(*preshape)
 
     block_tsr_list = []
-    for b in blocks:
-        # Get a TSR to move near the block.
-        tsr_list = robot.tsrlibrary(b, 'grasp', manip=manip)
-        block_tsr_list += tsr_list
+    with env:
+        for b in blocks:
+            # Get a TSR to move near the block.
+            tsr_list = robot.tsrlibrary(b, 'grasp', manip=manip)
+            block_tsr_list += tsr_list
     
     # Plan to a pose above the block
     with RenderTSRList(block_tsr_list, robot.GetEnv()):
@@ -152,10 +153,11 @@ def PlaceBlock(robot, block, on_obj, manip=None, **kw_args):
     env = robot.GetEnv()
 
     # Get a tsr for this position
-    object_place_list = robot.tsrlibrary(on_obj, 'point_on', manip=manip)
-    place_tsr_list = robot.tsrlibrary(block, 'place_on', 
-                                      pose_tsr_chain=object_place_list[0], 
-                                      manip=manip)
+    with env:
+        object_place_list = robot.tsrlibrary(on_obj, 'point_on', manip=manip)
+        place_tsr_list = robot.tsrlibrary(block, 'place_on', 
+                                          pose_tsr_chain=object_place_list[0], 
+                                          manip=manip)
 
     # Plan there
     with prpy.viz.RenderTSRList(object_place_list, robot.GetEnv()):
@@ -172,5 +174,3 @@ def PlaceBlock(robot, block, on_obj, manip=None, **kw_args):
         while not env.CheckCollision(block) and block_pose[2,3] > 0.0:
             block_pose[2,3] -= 0.02
             block.SetTransform(block_pose)
-    
-    

--- a/src/herbpy/action/grasping.py
+++ b/src/herbpy/action/grasping.py
@@ -39,8 +39,9 @@ def PushGrasp(robot, obj, push_distance=0.1, manip=None,
        (if None, the 'grasp' tsr from tsrlibrary is used)
     @param render Render tsr samples and push direction vectors during planning
     """
-    if tsrlist is None:
-        tsrlist = robot.tsrlibrary(obj, 'push_grasp', push_distance=push_distance)
+    with env: 
+        if tsrlist is None:
+            tsrlist = robot.tsrlibrary(obj, 'push_grasp', push_distance=push_distance)
 
     HerbGrasp(robot, obj, manip=manip, preshape=preshape, 
               push_distance=push_distance,
@@ -72,8 +73,9 @@ def HerbGrasp(robot, obj, push_distance=None, manip=None,
     manip.hand.MoveHand(*preshape)
 
     # Get the grasp tsr
-    if tsrlist is None:
-        tsrlist = robot.tsrlibrary(obj, 'grasp')
+    with robot.GetEnv():
+        if tsrlist is None:
+            tsrlist = robot.tsrlibrary(obj, 'grasp')
     
     # Plan to the grasp
     with prpy.viz.RenderTSRList(tsrlist, robot.GetEnv(), render=render):
@@ -200,13 +202,14 @@ def Place(robot, obj, on_obj, manip=None, render=True, **kw_args):
         with robot.GetEnv():
             manip = robot.GetActiveManipulator()
 
-    # Get a tsr to sample places to put the glass
-    obj_extents = obj.ComputeAABB().extents()
-    obj_radius = max(obj_extents[0], obj_extents[1])
-    tray_top_tsr = robot.tsrlibrary(on_obj, 'point_on', padding=obj_radius)
+    with robot.GetEnv():
+        # Get a tsr to sample places to put the glass
+        obj_extents = obj.ComputeAABB().extents()
+        obj_radius = max(obj_extents[0], obj_extents[1])
+        tray_top_tsr = robot.tsrlibrary(on_obj, 'point_on', padding=obj_radius)
 
-    #  Now use this to get a tsr for sampling ee_poses
-    place_tsr = robot.tsrlibrary(obj, 'place', pose_tsr_chain = tray_top_tsr[0])
+        #  Now use this to get a tsr for sampling ee_poses
+        place_tsr = robot.tsrlibrary(obj, 'place', pose_tsr_chain = tray_top_tsr[0])
 
     # Plan to the grasp
     with prpy.viz.RenderTSRList(place_tsr, robot.GetEnv(), render=render):

--- a/src/herbpy/action/rogue.py
+++ b/src/herbpy/action/rogue.py
@@ -100,7 +100,9 @@ def Point(robot, coord, manip=None, render=False):
 
     focus_trans = numpy.eye(4, dtype='float')
     focus_trans[0:3, 3] = coord
-    point_tsr = robot.tsrlibrary(None, 'point', focus_trans, manip)
+
+    with robot.GetEnv():
+        point_tsr = robot.tsrlibrary(None, 'point', focus_trans, manip)
 
     p = openravepy.KinBody.SaveParameters
     with robot.CreateRobotStateSaver(p.ActiveManipulator | p.ActiveDOF):
@@ -128,7 +130,9 @@ def Present(robot, coord, manip=None, render=True):
 
     focus_trans = numpy.eye(4, dtype='float')
     focus_trans[0:3, 3] = coord
-    present_tsr = robot.tsrlibrary(None, 'present', focus_trans, manip)
+
+    with robot.GetEnv():
+        present_tsr = robot.tsrlibrary(None, 'present', focus_trans, manip)
     
     p = openravepy.KinBody.SaveParameters
     with robot.CreateRobotStateSaver(p.ActiveManipulator | p.ActiveDOF):
@@ -186,7 +190,8 @@ def Sweep(robot, start_coords, end_coords, manip=None, margin=0.3, render=True):
         manip.PlanToEndEffectorPose(hand_pose, execute=True)
 
     #TSR to sweep to end position
-    sweep_tsr = robot.tsrlibrary(None, 'sweep', end_trans, manip)
+    with robot.GetEnv():
+        sweep_tsr = robot.tsrlibrary(None, 'sweep', end_trans, manip)
 
     p = openravepy.KinBody.SaveParameters
     with robot.CreateRobotStateSaver(p.ActiveManipulator | p.ActiveDOF):

--- a/src/herbpy/tsr/block.py
+++ b/src/herbpy/tsr/block.py
@@ -15,9 +15,8 @@ def block_grasp(robot, block, manip=None):
         manip_idx = robot.GetActiveManipulatorIndex()
         manip = robot.GetActiveManipulator()
     else:
-        with manip.GetRobot():
-            manip.SetActive()
-            manip_idx = manip.GetRobot().GetActiveManipulatorIndex()
+        manip.SetActive()
+        manip_idx = manip.GetRobot().GetActiveManipulatorIndex()
 
     offset = 0.01 #vertical offset relative to block
     alpha = 0.8 # orientation of end-effector relative to block
@@ -31,10 +30,10 @@ def block_grasp(robot, block, manip=None):
     Bw = numpy.zeros((6,2))
     Bw[5,:] = [-numpy.pi, numpy.pi]
         
-    pose_tsr = prpy.tsr.TSR(T0_w = block_in_world,
-                             Tw_e = ee_in_block,
-                             Bw = Bw,
-                             manip = manip_idx)
+    pose_tsr = TSR(T0_w = block_in_world,
+                   Tw_e = ee_in_block,
+                   Bw = Bw,
+                   manip = manip_idx)
 
     pose_tsr_chain = TSRChain(sample_start=False, 
                               sample_goal = True,
@@ -57,9 +56,8 @@ def block_at_pose(robot, block, position, manip=None):
         manip_idx = robot.GetActiveManipulatorIndex()
         manip = robot.GetActiveManipulator()
     else:
-        with manip.GetRobot():
-            manip.SetActive()
-            manip_idx = manip.GetRobot().GetActiveManipulatorIndex()
+        manip.SetActive()
+        manip_idx = manip.GetRobot().GetActiveManipulatorIndex()
 
     # Block on the object
     T0_w = numpy.eye(4)
@@ -100,9 +98,8 @@ def block_on_surface(robot, block, pose_tsr_chain, manip=None):
         manip_idx = robot.GetActiveManipulatorIndex()
         manip = robot.GetActiveManipulator()
     else:
-        with manip.GetRobot():
-            manip.SetActive()
-            manip_idx = manip.GetRobot().GetActiveManipulatorIndex()
+        manip.SetActive()
+        manip_idx = manip.GetRobot().GetActiveManipulatorIndex()
 
     block_pose = block.GetTransform()
     block_pose[:3,:3] = numpy.eye(3) # ignore orientation

--- a/src/herbpy/tsr/block.py
+++ b/src/herbpy/tsr/block.py
@@ -1,6 +1,6 @@
 import numpy
-import prpy.tsr 
 from prpy.tsr.tsrlibrary import TSRFactory
+from prpy.tsr.tsr import TSR, TSRChain
 
 @TSRFactory('herb', 'block', 'grasp')
 def block_grasp(robot, block, manip=None):
@@ -36,9 +36,9 @@ def block_grasp(robot, block, manip=None):
                              Bw = Bw,
                              manip = manip_idx)
 
-    pose_tsr_chain = prpy.tsr.TSRChain(sample_start=False, 
-                                        sample_goal = True,
-                                        TSRs = [pose_tsr])
+    pose_tsr_chain = TSRChain(sample_start=False, 
+                              sample_goal = True,
+                              TSRs = [pose_tsr])
     return [pose_tsr_chain]
             
 @TSRFactory('herb', 'block', 'place')
@@ -68,20 +68,20 @@ def block_at_pose(robot, block, position, manip=None):
     Bw = numpy.zeros((6,2))
     Bw[5,:] = [-numpy.pi, numpy.pi]
 
-    place_tsr = prpy.tsr.TSR(T0_w = T0_w,
-                             Tw_e = numpy.eye(4),
-                             Bw = Bw,
-                             manip = manip_idx)
+    place_tsr = TSR(T0_w = T0_w,
+                    Tw_e = numpy.eye(4),
+                    Bw = Bw,
+                    manip = manip_idx)
 
     ee_in_block = numpy.dot(numpy.linalg.inv(block.GetTransform()), manip.GetEndEffectorTransform())
-    ee_tsr = prpy.tsr.TSR(T0_w = numpy.eye(4), #ignored
-                          Tw_e = ee_in_block,
-                          Bw = numpy.zeros((6,2)),
-                          manip = manip_idx)
+    ee_tsr = TSR(T0_w = numpy.eye(4), #ignored
+                 Tw_e = ee_in_block,
+                 Bw = numpy.zeros((6,2)),
+                 manip = manip_idx)
 
-    place_tsr_chain = prpy.tsr.TSRChain(sample_start=False, 
-                                        sample_goal = True,
-                                        TSRs = [place_tsr, ee_tsr])
+    place_tsr_chain = TSRChain(sample_start=False, 
+                               sample_goal = True,
+                               TSRs = [place_tsr, ee_tsr])
     return [place_tsr_chain]
 
 @TSRFactory('herb', 'block', 'place_on')        
@@ -114,10 +114,9 @@ def block_on_surface(robot, block, pose_tsr_chain, manip=None):
         if tsr.manipindex != manip_idx:
             raise ValueError('pose_tsr_chain defined for a different manipulator.')
 
-    grasp_tsr = prpy.tsr.TSR(Tw_e = ee_in_block, Bw = Bw, manip = manip_idx)
+    grasp_tsr = TSR(Tw_e = ee_in_block, Bw = Bw, manip = manip_idx)
     all_tsrs = list(pose_tsr_chain.TSRs) + [grasp_tsr]
-    place_chain = prpy.tsr.TSRChain(sample_start = False, sample_goal = True, constrain = False,
+    place_chain = TSRChain(sample_start = False, sample_goal = True, constrain = False,
                            TSRs = all_tsrs)
 
     return  [ place_chain ]
-

--- a/src/herbpy/tsr/block_bin.py
+++ b/src/herbpy/tsr/block_bin.py
@@ -1,7 +1,8 @@
 import numpy, prpy
-import prpy.tsr
+from prpy.tsr.tsrlibrary import TSRFactory
+from prpy.tsr.tsr import TSR, TSRChain
 
-@prpy.tsr.tsrlibrary.TSRFactory('herb', 'block_bin', 'point_on')
+@TSRFactory('herb', 'block_bin', 'point_on')
 def point_on(robot, block_bin, manip=None, padding=0.04):
     '''
     This creates a TSR that allows you to sample poses on the tray.
@@ -40,9 +41,7 @@ def point_on(robot, block_bin, manip=None, padding=0.04):
     Bw[5,:] = [-numpy.pi, numpy.pi] # allow any rotation around z - which is the axis normal to the tray top
 
     
-    manip_tsr = prpy.tsr.TSR(T0_w = T0_w, Tw_e = Tw_e, Bw = Bw, manip = manip_idx)
-    tsr_chain = prpy.tsr.TSRChain(sample_start = False, sample_goal = True, constrain=False, 
+    manip_tsr = TSR(T0_w = T0_w, Tw_e = Tw_e, Bw = Bw, manip = manip_idx)
+    tsr_chain = TSRChain(sample_start = False, sample_goal = True, constrain=False, 
                                TSR = manip_tsr)
     return [tsr_chain]
-
-

--- a/src/herbpy/tsr/block_bin.py
+++ b/src/herbpy/tsr/block_bin.py
@@ -1,4 +1,4 @@
-import numpy, prpy
+import numpy
 from prpy.tsr.tsrlibrary import TSRFactory
 from prpy.tsr.tsr import TSR, TSRChain
 
@@ -6,42 +6,43 @@ from prpy.tsr.tsr import TSR, TSRChain
 def point_on(robot, block_bin, manip=None, padding=0.04):
     '''
     This creates a TSR that allows you to sample poses on the tray.
-    The samples from this TSR should be used to find points for object placement.
-    They are directly on the tray, and thus not suitable as an end-effector pose.
-    Grasp specific calculations are necessary to find a suitable end-effector pose.
+    The samples from this TSR should be used to find points for
+    object placement. They are directly on the tray, and thus not
+    suitable as an end-effector pose. Grasp specific calculations are
+    necessary to find a suitable end-effector pose.
 
     @param robot The robot performing the grasp
     @param tray The tray to sample poses on
     @param manip The manipulator to perform the grasp, if None
        the active manipulator on the robot is used
-    @param padding The amount of space around the edge to exclude from sampling
-       If using this to place an object, this would be the maximum radius of the object
-    @param handle_padding If true add extra padding along the edges of the tray that
-       have the handles to prevent choosing a pose too near the handle of the tray
+    @param padding The amount of space around the edge to exclude
+       from sampling. If using this to place an object, this would
+       be the maximum radius of the object
+    @param handle_padding If true add extra padding along the edges
+       of the tray that have the handles to prevent choosing a pose
+       too near the handle of the tray
     '''
     if manip is None:
         manip_idx = robot.GetActiveManipulatorIndex()
     else:
-        with manip.GetRobot():
-            manip.SetActive()
-            manip_idx = manip.GetRobot().GetActiveManipulatorIndex()
-            
+        manip.SetActive()
+        manip_idx = manip.GetRobot().GetActiveManipulatorIndex()
+
     T0_w = block_bin.GetTransform() # Coordinate system on bottom of bin
 
     Tw_e = numpy.eye(4)
-    Tw_e[2,3] = 0.17 # set the object on top of the bin - bin is 13cm high
+    Tw_e[2, 3] = 0.17 # set the object on top of the bin - bin is 13cm high
 
-    Bw = numpy.zeros((6,2))
+    Bw = numpy.zeros((6, 2))
 
     xdim = max(0.085 - padding, 0.0)
     ydim = max(0.135 - padding, 0.0)
-    Bw[0,:] = [-xdim, xdim ] # move along x and y directions to get any point on tray
-    Bw[1,:] = [-ydim, ydim]
-    Bw[2,:] = [-0.02, 0.04] # verticle movement
-    Bw[5,:] = [-numpy.pi, numpy.pi] # allow any rotation around z - which is the axis normal to the tray top
+    Bw[0, :] = [-xdim, xdim] # move along x, y directions to get any point on tray
+    Bw[1, :] = [-ydim, ydim]
+    Bw[2, :] = [-0.02, 0.04] # verticle movement
+    Bw[5, :] = [-numpy.pi, numpy.pi] # allow any rotation around z - which is the axis normal to the tray top
 
-    
     manip_tsr = TSR(T0_w = T0_w, Tw_e = Tw_e, Bw = Bw, manip = manip_idx)
-    tsr_chain = TSRChain(sample_start = False, sample_goal = True, constrain=False, 
-                               TSR = manip_tsr)
+    tsr_chain = TSRChain(sample_start = False, sample_goal = True, constrain=False,
+                         TSR = manip_tsr)
     return [tsr_chain]

--- a/src/herbpy/tsr/bowl.py
+++ b/src/herbpy/tsr/bowl.py
@@ -2,7 +2,7 @@ import numpy
 from prpy.tsr.tsrlibrary import TSRFactory
 from prpy.tsr.tsr import TSR, TSRChain
 
-@prpy.tsr.tsrlibrary.TSRFactory('herb', 'plastic_bowl', 'grasp')
+@TSRFactory('herb', 'plastic_bowl', 'grasp')
 def bowl_grasp(robot, bowl, manip=None):
     '''
     @param robot The robot performing the grasp

--- a/src/herbpy/tsr/fuze.py
+++ b/src/herbpy/tsr/fuze.py
@@ -1,7 +1,8 @@
 import numpy
-import prpy.tsr
+from prpy.tsr.tsrlibrary import TSRFactory
+from prpy.tsr.tsr import TSR, TSRChain
 
-@prpy.tsr.tsrlibrary.TSRFactory('herb', 'fuze_bottle', 'grasp')
+@TSRFactory('herb', 'fuze_bottle', 'grasp')
 def fuze_grasp(robot, fuze, manip=None):
     """
     @param robot The robot performing the grasp
@@ -11,7 +12,7 @@ def fuze_grasp(robot, fuze, manip=None):
     """
     return _fuze_grasp(robot, fuze, manip = manip)
 
-@prpy.tsr.tsrlibrary.TSRFactory('herb', 'fuze_bottle', 'push_grasp')
+@TSRFactory('herb', 'fuze_bottle', 'push_grasp')
 def fuze_grasp(robot, fuze, push_distance = 0.1, manip=None):
     """
     @param robot The robot performing the grasp
@@ -51,9 +52,9 @@ def _fuze_grasp(robot, fuze, push_distance = 0.0, manip = None):
     Bw[2,:] = [0.0, 0.02]  # Allow a little vertical movement
     Bw[5,:] = [-numpy.pi, numpy.pi]  # Allow any orientation
     
-    grasp_tsr = prpy.tsr.TSR(T0_w = T0_w, Tw_e = Tw_e, Bw = Bw, manip = manip_idx)
-    grasp_chain = prpy.tsr.TSRChain(sample_start=False, sample_goal = True, 
-                                    constrain=False, TSR = grasp_tsr)
+    grasp_tsr = TSR(T0_w = T0_w, Tw_e = Tw_e, Bw = Bw, manip = manip_idx)
+    grasp_chain = TSRChain(sample_start=False, sample_goal = True, 
+                           constrain=False, TSR = grasp_tsr)
 
     return [grasp_chain]
 

--- a/src/herbpy/tsr/fuze.py
+++ b/src/herbpy/tsr/fuze.py
@@ -34,9 +34,8 @@ def _fuze_grasp(robot, fuze, push_distance = 0.0, manip = None):
     if manip is None:
         manip_idx = robot.GetActiveManipulatorIndex()
     else:
-        with manip.GetRobot():
-            manip.SetActive()
-            manip_idx = manip.GetRobot().GetActiveManipulatorIndex()
+        manip.SetActive()
+        manip_idx = manip.GetRobot().GetActiveManipulatorIndex()
 
     T0_w = fuze.GetTransform()
     ee_to_palm_distance = 0.18

--- a/src/herbpy/tsr/generic.py
+++ b/src/herbpy/tsr/generic.py
@@ -138,7 +138,6 @@ def sweep_objs(robot, transform, manip=None):
     movement_chain = TSRChain(sample_start = False, sample_goal = False,
             constrain = True, TSRs = [tsr_constraint])
 
-
     return [goal_tsr_chain, movement_chain]
 
 @TSRFactory('herb', None, 'lift')
@@ -158,9 +157,8 @@ def lift_obj(robot, transform=numpy.eye(4), manip=None, distance=0.1, epsilon=0.
         manip = robot.GetActiveManipulator()
         manip_idx = robot.GetActiveManipulatorIndex()
     else:
-         with manip.GetRobot():
-             manip.SetActive()
-             manip_idx = manip.GetRobot().GetActiveManipulatorIndex()
+         manip.SetActive()
+         manip_idx = manip.GetRobot().GetActiveManipulatorIndex()
 
     #TSR for the goal
     start_position = manip.GetEndEffectorTransform()

--- a/src/herbpy/tsr/glass.py
+++ b/src/herbpy/tsr/glass.py
@@ -42,9 +42,8 @@ def _glass_grasp(robot, glass, manip=None, push_distance=0.0, **kw_args):
     if manip is None:
         manip_idx = robot.GetActiveManipulatorIndex()
     else:
-        with manip.GetRobot():
-            manip.SetActive()
-            manip_idx = manip.GetRobot().GetActiveManipulatorIndex()
+        manip.SetActive()
+        manip_idx = manip.GetRobot().GetActiveManipulatorIndex()
 
     T0_w = glass.GetTransform()
     
@@ -82,9 +81,8 @@ def glass_on_table(robot, glass, pose_tsr_chain, manip=None):
         manip_idx = robot.GetActiveManipulatorIndex()
         manip = robot.GetActiveManipulator()
     else:
-        with manip.GetRobot():
-            manip.SetActive()
-            manip_idx = manip.GetRobot().GetActiveManipulatorIndex()
+        manip.SetActive()
+        manip_idx = manip.GetRobot().GetActiveManipulatorIndex()
 
     ee_in_glass = numpy.dot(numpy.linalg.inv(glass.GetTransform()), manip.GetEndEffectorTransform())
     ee_in_glass[2,3] += 0.04 # Let go slightly above table
@@ -122,9 +120,8 @@ def glass_transport(robot, glass, manip=None, roll_epsilon=0.2, pitch_epsilon=0.
         manip_idx = robot.GetActiveManipulatorIndex()
         manip = robot.GetActiveManipulator()
     else:
-        with manip.GetRobot():
-            manip.SetActive()
-            manip_idx = manip.GetRobot().GetActiveManipulatorIndex()
+        manip.SetActive()
+        manip_idx = manip.GetRobot().GetActiveManipulatorIndex()
 
     ee_in_glass = numpy.dot(numpy.linalg.inv(glass.GetTransform()), manip.GetEndEffectorTransform())
     Bw = numpy.array([[-100., 100.], # bounds that cover full reachability of manip

--- a/src/herbpy/tsr/glass.py
+++ b/src/herbpy/tsr/glass.py
@@ -1,7 +1,8 @@
 import numpy
-import prpy.tsr
+from prpy.tsr.tsrlibrary import TSRFactory
+from prpy.tsr.tsr import TSR, TSRChain
 
-@prpy.tsr.tsrlibrary.TSRFactory('herb', 'plastic_glass', 'grasp')
+@TSRFactory('herb', 'plastic_glass', 'grasp')
 def glass_grasp(robot, glass, manip=None, **kw_args):
     '''
     @param robot The robot performing the grasp
@@ -11,7 +12,7 @@ def glass_grasp(robot, glass, manip=None, **kw_args):
     '''
     return _glass_grasp(robot, glass, manip=manip, **kw_args)
     
-@prpy.tsr.tsrlibrary.TSRFactory('herb', 'plastic_glass', 'push_grasp')
+@TSRFactory('herb', 'plastic_glass', 'push_grasp')
 def glass_push_grasp(robot, glass, manip=None, push_distance=0.1, **kw_args):
     '''
     This factory differes from glass_grasp in that it places the manipulator 
@@ -59,13 +60,13 @@ def _glass_grasp(robot, glass, manip=None, push_distance=0.0, **kw_args):
     Bw[2,:] = [0.0, 0.02]  # Allow a little vertical movement
     Bw[5,:] = [-numpy.pi, numpy.pi]  # Allow any orientation
     
-    grasp_tsr = prpy.tsr.TSR(T0_w = T0_w, Tw_e = Tw_e, Bw = Bw, manip = manip_idx)
-    grasp_chain = prpy.tsr.TSRChain(sample_start=False, sample_goal = True, 
-                                    constrain=False, TSR = grasp_tsr)
+    grasp_tsr = TSR(T0_w = T0_w, Tw_e = Tw_e, Bw = Bw, manip = manip_idx)
+    grasp_chain = TSRChain(sample_start=False, sample_goal = True, 
+                           constrain=False, TSR = grasp_tsr)
 
     return [grasp_chain]
                 
-@prpy.tsr.tsrlibrary.TSRFactory('herb', 'plastic_glass', 'place')
+@TSRFactory('herb', 'plastic_glass', 'place')
 def glass_on_table(robot, glass, pose_tsr_chain, manip=None):
     '''
     Generates end-effector poses for placing the glass on the table.
@@ -94,14 +95,14 @@ def glass_on_table(robot, glass, pose_tsr_chain, manip=None):
         if tsr.manipindex != manip_idx:
             raise Exception('pose_tsr_chain defined for a different manipulator.')
 
-    grasp_tsr = prpy.tsr.TSR(Tw_e = ee_in_glass, Bw = Bw, manip = manip_idx)
+    grasp_tsr = TSR(Tw_e = ee_in_glass, Bw = Bw, manip = manip_idx)
     all_tsrs = list(pose_tsr_chain.TSRs) + [grasp_tsr]
-    place_chain = prpy.tsr.TSRChain(sample_start = False, sample_goal = True, constrain = False,
+    place_chain = TSRChain(sample_start = False, sample_goal = True, constrain = False,
                            TSRs = all_tsrs)
 
     return  [ place_chain ]
     
-@prpy.tsr.tsrlibrary.TSRFactory('herb', 'plastic_glass', 'transport')
+@TSRFactory('herb', 'plastic_glass', 'transport')
 def glass_transport(robot, glass, manip=None, roll_epsilon=0.2, pitch_epsilon=0.2, yaw_epsilon=0.2):
     '''
     Generates a trajectory-wide constraint for transporting the object with little roll, pitch or yaw
@@ -132,12 +133,12 @@ def glass_transport(robot, glass, manip=None, roll_epsilon=0.2, pitch_epsilon=0.
                       [-roll_epsilon, roll_epsilon],
                       [-pitch_epsilon, pitch_epsilon],
                       [-yaw_epsilon, yaw_epsilon]])
-    transport_tsr = prpy.tsr.TSR(T0_w = glass.GetTransform(),
-                                 Tw_e = ee_in_glass,
-                                 Bw = Bw,
-                                 manip = manip_idx)
+    transport_tsr = TSR(T0_w = glass.GetTransform(),
+                        Tw_e = ee_in_glass,
+                        Bw = Bw,
+                        manip = manip_idx)
 
-    transport_chain = prpy.tsr.TSRChain(sample_start = False, sample_goal=False, 
-                                        constrain=True, TSR = transport_tsr)
+    transport_chain = TSRChain(sample_start = False, sample_goal=False, 
+                               constrain=True, TSR = transport_tsr)
     
     return [ transport_chain ]

--- a/src/herbpy/tsr/pill_bottle.py
+++ b/src/herbpy/tsr/pill_bottle.py
@@ -1,7 +1,8 @@
 import numpy
-import prpy.tsr
+from prpy.tsr.tsrlibrary import TSRFactory
+from prpy.tsr.tsr import TSR, TSRChain
 
-@prpy.tsr.tsrlibrary.TSRFactory('herb', 'pill_bottle', 'grasp')
+@TSRFactory('herb', 'pill_bottle', 'grasp')
 def pills_grasp(robot, pills, manip=None, **kw_args):
     '''
     @param robot The robot performing the grasp
@@ -11,7 +12,7 @@ def pills_grasp(robot, pills, manip=None, **kw_args):
     '''
     return _pills_grasp(robot, pills, manip=manip, **kw_args)
     
-@prpy.tsr.tsrlibrary.TSRFactory('herb', 'pill_bottle', 'push_grasp')
+@TSRFactory('herb', 'pill_bottle', 'push_grasp')
 def pills_push_grasp(robot, pills, manip=None, push_distance=0.1, **kw_args):
     '''
     This factory differes from pills_grasp in that it places the manipulator 
@@ -59,13 +60,13 @@ def _pills_grasp(robot, pills, manip=None, push_distance=0.0, **kw_args):
     Bw[2,:] = [0.0, 0.02]  # Allow a little vertical movement
     Bw[5,:] = [-numpy.pi, numpy.pi]  # Allow any orientation
     
-    grasp_tsr = prpy.tsr.TSR(T0_w = T0_w, Tw_e = Tw_e, Bw = Bw, manip = manip_idx)
-    grasp_chain = prpy.tsr.TSRChain(sample_start=False, sample_goal = True, 
+    grasp_tsr = TSR(T0_w = T0_w, Tw_e = Tw_e, Bw = Bw, manip = manip_idx)
+    grasp_chain = TSRChain(sample_start=False, sample_goal = True, 
                                     constrain=False, TSR = grasp_tsr)
 
     return [grasp_chain]
                 
-@prpy.tsr.tsrlibrary.TSRFactory('herb', 'pill_bottle', 'place')
+@TSRFactory('herb', 'pill_bottle', 'place')
 def pills_on_table(robot, pills, pose_tsr_chain, manip=None):
     '''
     Generates end-effector poses for placing the pill bottle on the table.
@@ -94,14 +95,14 @@ def pills_on_table(robot, pills, pose_tsr_chain, manip=None):
         if tsr.manipindex != manip_idx:
             raise Exception('pose_tsr_chain defined for a different manipulator.')
 
-    grasp_tsr = prpy.tsr.TSR(Tw_e = ee_in_glass, Bw = Bw, manip = manip_idx)
+    grasp_tsr = TSR(Tw_e = ee_in_glass, Bw = Bw, manip = manip_idx)
     all_tsrs = list(pose_tsr_chain.TSRs) + [grasp_tsr]
-    place_chain = prpy.tsr.TSRChain(sample_start = False, sample_goal = True, constrain = False,
+    place_chain = TSRChain(sample_start = False, sample_goal = True, constrain = False,
                            TSRs = all_tsrs)
 
     return  [ place_chain ]
     
-@prpy.tsr.tsrlibrary.TSRFactory('herb', 'pill_bottle', 'transport')
+@TSRFactory('herb', 'pill_bottle', 'transport')
 def pills_transport(robot, pills, manip=None, roll_epsilon=0.2, pitch_epsilon=0.2, yaw_epsilon=0.2):
     '''
     Generates a trajectory-wide constraint for transporting the object with little roll, pitch or yaw
@@ -132,12 +133,12 @@ def pills_transport(robot, pills, manip=None, roll_epsilon=0.2, pitch_epsilon=0.
                       [-roll_epsilon, roll_epsilon],
                       [-pitch_epsilon, pitch_epsilon],
                       [-yaw_epsilon, yaw_epsilon]])
-    transport_tsr = prpy.tsr.TSR(T0_w = glass.GetTransform(),
-                                 Tw_e = ee_in_glass,
-                                 Bw = Bw,
-                                 manip = manip_idx)
+    transport_tsr = TSR(T0_w = glass.GetTransform(),
+                        Tw_e = ee_in_glass,
+                        Bw = Bw,
+                        manip = manip_idx)
 
-    transport_chain = prpy.tsr.TSRChain(sample_start = False, sample_goal=False, 
-                                        constrain=True, TSR = transport_tsr)
+    transport_chain = TSRChain(sample_start = False, sample_goal=False, 
+                               constrain=True, TSR = transport_tsr)
     
     return [ transport_chain ]

--- a/src/herbpy/tsr/pill_bottle.py
+++ b/src/herbpy/tsr/pill_bottle.py
@@ -42,9 +42,8 @@ def _pills_grasp(robot, pills, manip=None, push_distance=0.0, **kw_args):
     if manip is None:
         manip_idx = robot.GetActiveManipulatorIndex()
     else:
-        with manip.GetRobot():
-            manip.SetActive()
-            manip_idx = manip.GetRobot().GetActiveManipulatorIndex()
+        manip.SetActive()
+        manip_idx = manip.GetRobot().GetActiveManipulatorIndex()
 
     T0_w = pills.GetTransform()
     
@@ -82,9 +81,8 @@ def pills_on_table(robot, pills, pose_tsr_chain, manip=None):
         manip_idx = robot.GetActiveManipulatorIndex()
         manip = robot.GetActiveManipulator()
     else:
-        with manip.GetRobot():
-            manip.SetActive()
-            manip_idx = manip.GetRobot().GetActiveManipulatorIndex()
+        manip.SetActive()
+        manip_idx = manip.GetRobot().GetActiveManipulatorIndex()
 
     ee_in_glass = numpy.dot(numpy.linalg.inv(pills.GetTransform()), manip.GetEndEffectorTransform())
     ee_in_glass[2,3] += 0.04 # Let go slightly above table
@@ -122,9 +120,8 @@ def pills_transport(robot, pills, manip=None, roll_epsilon=0.2, pitch_epsilon=0.
         manip_idx = robot.GetActiveManipulatorIndex()
         manip = robot.GetActiveManipulator()
     else:
-        with manip.GetRobot():
-            manip.SetActive()
-            manip_idx = manip.GetRobot().GetActiveManipulatorIndex()
+        manip.SetActive()
+        manip_idx = manip.GetRobot().GetActiveManipulatorIndex()
 
     ee_in_glass = numpy.dot(numpy.linalg.inv(pills.GetTransform()), manip.GetEndEffectorTransform())
     Bw = numpy.array([[-100., 100.], # bounds that cover full reachability of manip

--- a/src/herbpy/tsr/pitcher.py
+++ b/src/herbpy/tsr/pitcher.py
@@ -1,7 +1,8 @@
 import numpy
-import prpy.tsr
+from prpy.tsr.tsrlibrary import TSRFactory
+from prpy.tsr.tsr import TSR, TSRChain
 
-@prpy.tsr.tsrlibrary.TSRFactory('herb', 'rubbermaid_ice_guard_pitcher', 'grasp')
+@TSRFactory('herb', 'rubbermaid_ice_guard_pitcher', 'grasp')
 def pitcher_grasp(robot, pitcher, manip=None):
     '''
     @param robot The robot performing the grasp
@@ -25,13 +26,13 @@ def pitcher_grasp(robot, pitcher, manip=None):
     Bw = numpy.zeros((6,2))
     Bw[2,:] = [-0.01, 0.01]  # Allow a little vertical movement
     
-    grasp_tsr = prpy.tsr.TSR(T0_w = T0_w, Tw_e = Tw_e, Bw = Bw, manip = manip_idx)
-    grasp_chain = prpy.tsr.TSRChain(sample_start=False, sample_goal = True, 
-                                    constrain=False, TSR = grasp_tsr)
+    grasp_tsr = TSR(T0_w = T0_w, Tw_e = Tw_e, Bw = Bw, manip = manip_idx)
+    grasp_chain = TSRChain(sample_start=False, sample_goal = True, 
+                           constrain=False, TSR = grasp_tsr)
 
     return [grasp_chain]
         
-@prpy.tsr.tsrlibrary.TSRFactory('herb', 'rubbermaid_ice_guard_pitcher', 'pour')
+@TSRFactory('herb', 'rubbermaid_ice_guard_pitcher', 'pour')
 def pitcher_pour(robot, pitcher, min_tilt = 1.4, max_tilt = 1.57, manip=None, grasp_transform = None, 
                  pitcher_pose = None):
     '''
@@ -72,14 +73,14 @@ def pitcher_pour(robot, pitcher, min_tilt = 1.4, max_tilt = 1.57, manip=None, gr
     Bw_pour[4,:] = [0, 2*numpy.pi ]
     Bw_pour[3,:] = [-10*numpy.pi/180, 10*numpy.pi/180]
         
-    tsr_0 = prpy.tsr.TSR(T0_w = pitcher_pose,
-                         Tw_e = spout_in_pitcher,
-                         Bw = numpy.zeros((6,2)),
-                         manip = manip_idx)
+    tsr_0 = TSR(T0_w = pitcher_pose,
+                Tw_e = spout_in_pitcher,
+                Bw = numpy.zeros((6,2)),
+                manip = manip_idx)
 
-    tsr_1_constraint = prpy.tsr.TSR(Tw_e = ee_in_spout,
-                                    Bw = Bw_pour,
-                                    manip = manip_idx)
+    tsr_1_constraint = TSR(Tw_e = ee_in_spout,
+                           Bw = Bw_pour,
+                           manip = manip_idx)
 
     pour_chain = prpy.tsr.TSRChain(sample_start = False,
                                    sample_goal = False,
@@ -88,12 +89,12 @@ def pitcher_pour(robot, pitcher, min_tilt = 1.4, max_tilt = 1.57, manip=None, gr
 
     Bw_goal = numpy.zeros((6,2))
     Bw_goal[4,:] = [ min_tilt, max_tilt ]
-    tsr_1_goal = prpy.tsr.TSR(Tw_e = ee_in_spout,
-                              Bw = Bw_goal,
-                              manip = manip_idx)
-    pour_goal = prpy.tsr.TSRChain(sample_start = False,
-                                  sample_goal = True,
-                                  constrain = False,
-                                  TSRs = [tsr_0, tsr_1_goal])
+    tsr_1_goal = TSR(Tw_e = ee_in_spout,
+                     Bw = Bw_goal,
+                     manip = manip_idx)
+    pour_goal = TSRChain(sample_start = False,
+                         sample_goal = True,
+                         constrain = False,
+                         TSRs = [tsr_0, tsr_1_goal])
 
     return [pour_chain, pour_goal], min_tilt, max_tilt

--- a/src/herbpy/tsr/pitcher.py
+++ b/src/herbpy/tsr/pitcher.py
@@ -14,9 +14,8 @@ def pitcher_grasp(robot, pitcher, manip=None):
     if manip is None:
         manip_idx = robot.GetActiveManipulatorIndex()
     else:
-        with manip.GetRobot():
-            manip.SetActive()
-            manip_idx = manip.GetRobot().GetActiveManipulatorIndex()
+        manip.SetActive()
+        manip_idx = manip.GetRobot().GetActiveManipulatorIndex()
 
     T0_w = pitcher.GetTransform()
     Tw_e = numpy.array([[0.802, 0., -0.596, 0.199], 
@@ -49,9 +48,8 @@ def pitcher_pour(robot, pitcher, min_tilt = 1.4, max_tilt = 1.57, manip=None, gr
         manip = robot.GetActiveManipulator()
         manip_idx = robot.GetActiveManipulatorIndex()
     else:
-        with manip.GetRobot():
-            manip.SetActive()
-            manip_idx = manip.GetRobot().GetActiveManipulatorIndex()
+        manip.SetActive()
+        manip_idx = manip.GetRobot().GetActiveManipulatorIndex()
 
     if pitcher_pose is None:
         pitcher_pose = pitcher.GetTransform()
@@ -82,10 +80,10 @@ def pitcher_pour(robot, pitcher, min_tilt = 1.4, max_tilt = 1.57, manip=None, gr
                            Bw = Bw_pour,
                            manip = manip_idx)
 
-    pour_chain = prpy.tsr.TSRChain(sample_start = False,
-                                   sample_goal = False,
-                                   constrain = True,
-                                   TSRs = [tsr_0, tsr_1_constraint])
+    pour_chain = TSRChain(sample_start = False,
+                          sample_goal = False,
+                          constrain = True,
+                          TSRs = [tsr_0, tsr_1_constraint])
 
     Bw_goal = numpy.zeros((6,2))
     Bw_goal[4,:] = [ min_tilt, max_tilt ]

--- a/src/herbpy/tsr/plate.py
+++ b/src/herbpy/tsr/plate.py
@@ -1,7 +1,8 @@
 import numpy
-import prpy.tsr
+from prpy.tsr.tsrlibrary import TSRFactory
+from prpy.tsr.tsr import TSR, TSRChain
 
-@prpy.tsr.tsrlibrary.TSRFactory('herb', 'plastic_plate', 'grasp')
+@TSRFactory('herb', 'plastic_plate', 'grasp')
 def plate_grasp(robot, plate, manip=None):
     '''
     @param robot The robot performing the grasp
@@ -26,13 +27,13 @@ def plate_grasp(robot, plate, manip=None):
     Bw[2,:] = [0.0, 0.01] # Allow a little verticle movement
     Bw[5,:] = [-numpy.pi, numpy.pi] # Allow any point around the edge of the plate
 
-    grasp_tsr = prpy.tsr.TSR(T0_w = T0_w, Tw_e = Tw_e, Bw = Bw, manip = manip_idx)
-    grasp_chain = prpy.tsr.TSRChain(sample_start=False, sample_goal = True, 
-                                    constrain=False, TSR = grasp_tsr)
+    grasp_tsr = TSR(T0_w = T0_w, Tw_e = Tw_e, Bw = Bw, manip = manip_idx)
+    grasp_chain = TSRChain(sample_start=False, sample_goal = True, 
+                           constrain=False, TSR = grasp_tsr)
 
     return [grasp_chain]
     
-@prpy.tsr.tsrlibrary.TSRFactory('herb', 'plastic_plate', 'place')
+@TSRFactory('herb', 'plastic_plate', 'place')
 def plate_on_table(robot, plate, pose_tsr_chain, manip=None):
     '''
     Generates end-effector poses for placing the plate on the table.
@@ -87,10 +88,10 @@ def plate_on_table(robot, plate, pose_tsr_chain, manip=None):
     #plate_tsr = TSR(Tw_e = tilted_plate_in_table, Bw = numpy.zeros((6,2)), manip = manip_idx)
     plate_in_table = numpy.eye(4)
     plate_in_table[2,3] = 0.20
-    plate_tsr = prpy.tsr.TSR(Tw_e = plate_in_table, Bw = numpy.zeros((6,2)), manip = manip_idx)
-    grasp_tsr = prpy.tsr.TSR(Tw_e = ee_in_plate, Bw = Bw, manip = manip_idx)
+    plate_tsr = TSR(Tw_e = plate_in_table, Bw = numpy.zeros((6,2)), manip = manip_idx)
+    grasp_tsr = TSR(Tw_e = ee_in_plate, Bw = Bw, manip = manip_idx)
     all_tsrs = list(pose_tsr_chain.TSRs) + [plate_tsr, grasp_tsr]
-    place_chain = prpy.tsr.TSRChain(sample_start = False, sample_goal = True, constrain = False,
+    place_chain = TSRChain(sample_start = False, sample_goal = True, constrain = False,
                            TSRs = all_tsrs)
 
     return  [ place_chain ]

--- a/src/herbpy/tsr/plate.py
+++ b/src/herbpy/tsr/plate.py
@@ -13,9 +13,8 @@ def plate_grasp(robot, plate, manip=None):
     if manip is None:
         manip_idx = robot.GetActiveManipulatorIndex()
     else:
-        with manip.GetRobot():
-            manip.SetActive()
-            manip_idx = manip.GetRobot().GetActiveManipulatorIndex()
+        manip.SetActive()
+        manip_idx = manip.GetRobot().GetActiveManipulatorIndex()
 
     plate_radius = plate.ComputeAABB().extents()[0]
     T0_w = plate.GetTransform()
@@ -49,9 +48,8 @@ def plate_on_table(robot, plate, pose_tsr_chain, manip=None):
         manip_idx = robot.GetActiveManipulatorIndex()
         manip = robot.GetActiveManipulator()
     else:
-        with manip.GetRobot():
-            manip.SetActive()
-            manip_idx = manip.GetRobot().GetActiveManipulatorIndex()
+        manip.SetActive()
+        manip_idx = manip.GetRobot().GetActiveManipulatorIndex()
 
     ee_in_plate = numpy.dot(numpy.linalg.inv(plate.GetTransform()), manip.GetEndEffectorTransform())
     Bw = numpy.zeros((6,2))

--- a/src/herbpy/tsr/pop_tarts.py
+++ b/src/herbpy/tsr/pop_tarts.py
@@ -34,9 +34,8 @@ def _poptarts_grasp(robot, pop_tarts, push_distance = 0.0, manip = None):
     if manip is None:
         manip_idx = robot.GetActiveManipulatorIndex()
     else:
-        with manip.GetRobot():
-            manip.SetActive()
-            manip_idx = manip.GetRobot().GetActiveManipulatorIndex()
+        manip.SetActive()
+        manip_idx = manip.GetRobot().GetActiveManipulatorIndex()
 
     T0_w = pop_tarts.GetTransform()
     ee_to_palm_distance = 0.18

--- a/src/herbpy/tsr/pop_tarts.py
+++ b/src/herbpy/tsr/pop_tarts.py
@@ -1,7 +1,8 @@
 import numpy
-import prpy.tsr
+from prpy.tsr.tsrlibrary import TSRFactory
+from prpy.tsr.tsr import TSR, TSRChain
 
-@prpy.tsr.tsrlibrary.TSRFactory('herb', 'pop_tarts', 'grasp')
+@TSRFactory('herb', 'pop_tarts', 'grasp')
 def poptarts_grasp(robot, pop_tarts, manip=None):
     """
     @param robot The robot performing the grasp
@@ -11,7 +12,7 @@ def poptarts_grasp(robot, pop_tarts, manip=None):
     """
     return _poptarts_grasp(robot, pop_tarts, manip = manip)
 
-@prpy.tsr.tsrlibrary.TSRFactory('herb', 'pop_tarts', 'push_grasp')
+@TSRFactory('herb', 'pop_tarts', 'push_grasp')
 def poptarts_grasp(robot, pop_tarts, push_distance = 0.1, manip=None):
     """
     @param robot The robot performing the grasp
@@ -51,9 +52,8 @@ def _poptarts_grasp(robot, pop_tarts, push_distance = 0.0, manip = None):
     Bw[2,:] = [0.0, 0.02]  # Allow a little vertical movement
     Bw[5,:] = [-numpy.pi, numpy.pi]  # Allow any orientation
     
-    grasp_tsr = prpy.tsr.TSR(T0_w = T0_w, Tw_e = Tw_e, Bw = Bw, manip = manip_idx)
-    grasp_chain = prpy.tsr.TSRChain(sample_start=False, sample_goal = True, 
+    grasp_tsr = TSR(T0_w = T0_w, Tw_e = Tw_e, Bw = Bw, manip = manip_idx)
+    grasp_chain = TSRChain(sample_start=False, sample_goal = True, 
             constrain=False, TSR = grasp_tsr)
 
     return [grasp_chain]
-

--- a/src/herbpy/tsr/table.py
+++ b/src/herbpy/tsr/table.py
@@ -18,9 +18,8 @@ def point_on(robot, table, manip=None):
     if manip is None:
         manip_idx = robot.GetActiveManipulatorIndex()
     else:
-        with manip.GetRobot():
-            manip.SetActive()
-            manip_idx = manip.GetRobot().GetActiveManipulatorIndex()
+        manip.SetActive()
+        manip_idx = manip.GetRobot().GetActiveManipulatorIndex()
             
     T0_w = table.GetTransform()
 

--- a/src/herbpy/tsr/table.py
+++ b/src/herbpy/tsr/table.py
@@ -1,7 +1,8 @@
 import numpy
-import prpy.tsr
+from prpy.tsr.tsrlibrary import TSRFactory
+from prpy.tsr.tsr import TSR, TSRChain
 
-@prpy.tsr.tsrlibrary.TSRFactory('herb', 'conference_table', 'point_on')
+@TSRFactory('herb', 'conference_table', 'point_on')
 def point_on(robot, table, manip=None):
     '''
     This creates a TSR that allows you to sample poses on the table.
@@ -33,7 +34,7 @@ def point_on(robot, table, manip=None):
     Bw[2,:] = [-0.38+padding, 0.38-padding]
     Bw[4,:] = [-numpy.pi, numpy.pi] # allow any rotation around y - which is the axis normal to the table top
     
-    table_top_tsr = prpy.tsr.TSR(T0_w = T0_w, Tw_e = Tw_e, Bw = Bw, manip = manip_idx)
-    table_top_chain = prpy.tsr.TSRChain(sample_start = False, sample_goal = True, constrain=False, 
+    table_top_tsr = TSR(T0_w = T0_w, Tw_e = Tw_e, Bw = Bw, manip = manip_idx)
+    table_top_chain = TSRChain(sample_start = False, sample_goal = True, constrain=False, 
                                TSR = table_top_tsr)
     return [table_top_chain]

--- a/src/herbpy/tsr/tray.py
+++ b/src/herbpy/tsr/tray.py
@@ -1,7 +1,8 @@
 import numpy, prpy
-import prpy.tsr
+from prpy.tsr.tsrlibrary import TSRFactory
+from prpy.tsr.tsr import TSR, TSRChain
 
-@prpy.tsr.tsrlibrary.TSRFactory('herb', 'wicker_tray', 'point_on')
+@TSRFactory('herb', 'wicker_tray', 'point_on')
 def point_on(robot, tray, manip=None, padding=0.0, handle_padding=True):
     '''
     This creates a TSR that allows you to sample poses on the tray.
@@ -44,13 +45,12 @@ def point_on(robot, tray, manip=None, padding=0.0, handle_padding=True):
     Bw[5,:] = [-numpy.pi, numpy.pi] # allow any rotation around z - which is the axis normal to the tray top
 
     
-    tray_top_tsr = prpy.tsr.TSR(T0_w = T0_w, Tw_e = Tw_e, Bw = Bw, manip = manip_idx)
-    tray_top_chain = prpy.tsr.TSRChain(sample_start = False, sample_goal = True, constrain=False, 
-                               TSR = tray_top_tsr)
+    tray_top_tsr = TSR(T0_w = T0_w, Tw_e = Tw_e, Bw = Bw, manip = manip_idx)
+    tray_top_chain = TSRChain(sample_start = False, sample_goal = True, constrain=False, 
+                              TSR = tray_top_tsr)
     return [tray_top_chain]
 
-
-@prpy.tsr.tsrlibrary.TSRFactory('herb', 'wicker_tray', 'handle_grasp')
+@TSRFactory('herb', 'wicker_tray', 'handle_grasp')
 def handle_grasp(robot, tray, manip=None, handle=None):
     '''
     This creates a TSR for grasping the left handle of the tray
@@ -61,18 +61,14 @@ def handle_grasp(robot, tray, manip=None, handle=None):
     @param manip The manipulator to perform the grasp, if None
       the active manipulator on the robot is used
     '''
-    with robot.GetEnv():
-        if manip is None:
-            manip_idx = robot.GetActiveManipulatorIndex()
-        else:
-            from openravepy import Robot
-            with manip.GetRobot().CreateRobotStateSaver(
-                    Robot.SaveParameters.ActiveManipulator):
-                manip.GetRobot().SetActiveManipulator(manip)
-                manip_idx = manip.GetRobot().GetActiveManipulatorIndex()
+    if manip is None:
+        manip_idx = robot.GetActiveManipulatorIndex()
+    else:
+        manip.GetRobot().SetActiveManipulator(manip)
+        manip_idx = manip.GetRobot().GetActiveManipulatorIndex()
             
-        tray_in_world = tray.GetTransform()
-        ee_in_world = manip.GetEndEffectorTransform()
+    tray_in_world = tray.GetTransform()
+    ee_in_world = manip.GetEndEffectorTransform()
 
     # Compute the pose of both handles in the tray
     handle_one_in_tray = numpy.eye(4)
@@ -103,14 +99,14 @@ def handle_grasp(robot, tray, manip=None, handle=None):
         dist = numpy.linalg.norm(handle_in_world[:2,3] - ee_in_world[:2,3])
         if handle == 'closest' and dist > best_dist:
             continue
-        tray_grasp_tsr = prpy.tsr.TSR(T0_w = handle_in_world, 
-                                      Tw_e = grasp_in_handle, 
-                                      Bw = Bw, 
-                                      manip=manip_idx)
-        tray_grasp_chain = prpy.tsr.TSRChain(sample_start = False, 
-                                             sample_goal = True, 
-                                             constrain=False,
-                                             TSR = tray_grasp_tsr)
+        tray_grasp_tsr = TSR(T0_w = handle_in_world, 
+                             Tw_e = grasp_in_handle, 
+                             Bw = Bw, 
+                             manip=manip_idx)
+        tray_grasp_chain = TSRChain(sample_start = False, 
+                                    sample_goal = True, 
+                                    constrain=False,
+                                    TSR = tray_grasp_tsr)
         if handle == 'closest':
             chains = []
         chains.append(tray_grasp_chain)
@@ -129,12 +125,11 @@ def lift(robot, tray, distance=0.1):
     '''
     print 'distance = %0.2f' % distance
 
-    with robot:
-        robot.left_arm.SetActive()
-        left_manip_idx = robot.GetActiveManipulatorIndex()
+    robot.left_arm.SetActive()
+    left_manip_idx = robot.GetActiveManipulatorIndex()
 
-        robot.right_arm.SetActive()
-        right_manip_idx = robot.GetActiveManipulatorIndex()
+    robot.right_arm.SetActive()
+    right_manip_idx = robot.GetActiveManipulatorIndex()
 
     # First TSR defines a goal for the left arm
     left_in_world = robot.left_arm.GetEndEffectorTransform()
@@ -147,24 +142,24 @@ def lift(robot, tray, distance=0.1):
     Bw_left[1,:] = [-epsilon, epsilon]
     Bw_left[4,:] = [-epsilon, epsilon] # a little bit of tilt around handle
 
-    tsr_left_goal = prpy.tsr.TSR(T0_w = desired_left_in_world,
-                                 Tw_e = numpy.eye(4),
-                                 Bw = Bw_left,
-                                 manip = left_manip_idx)
+    tsr_left_goal = TSR(T0_w = desired_left_in_world,
+                        Tw_e = numpy.eye(4),
+                        Bw = Bw_left,
+                        manip = left_manip_idx)
 
     # Now define a TSR that is the right hand relative to the left
     right_in_world = robot.right_arm.GetEndEffectorTransform()
     right_in_left = numpy.dot(numpy.linalg.inv(left_in_world), right_in_world)
 
     Bw_right = numpy.zeros((6,2))
-    tsr_right_goal = prpy.tsr.TSR(T0_w = numpy.eye(4), # overwritten in planner
-                                  Tw_e = right_in_left,
-                                  Bw = Bw_right,
-                                  manip = right_manip_idx)
-    goal_tsr_chain = prpy.tsr.TSRChain(sample_start = False,
-                                       sample_goal = True,
-                                       constrain = False,
-                                       TSRs = [tsr_left_goal, tsr_right_goal])
+    tsr_right_goal = TSR(T0_w = numpy.eye(4), # overwritten in planner
+                         Tw_e = right_in_left,
+                         Bw = Bw_right,
+                         manip = right_manip_idx)
+    goal_tsr_chain = TSRChain(sample_start = False,
+                              sample_goal = True,
+                              constrain = False,
+                              TSRs = [tsr_left_goal, tsr_right_goal])
     
     # Now define a TSR that constrains the movement of the arms
     Bw_constrain = numpy.zeros((6,2))
@@ -179,22 +174,22 @@ def lift(robot, tray, distance=0.1):
     Bw_constrain[4,:] = [-epsilon, epsilon]
     Bw_constrain[5,:] = [-epsilon, epsilon]
 
-    tsr_left_constraint = prpy.tsr.TSR(T0_w = left_in_world,
-                                       Tw_e = numpy.eye(4),
-                                       Bw = Bw_constrain,
-                                       manip = left_manip_idx)
+    tsr_left_constraint = TSR(T0_w = left_in_world,
+                              Tw_e = numpy.eye(4),
+                              Bw = Bw_constrain,
+                              manip = left_manip_idx)
 
-    tsr_right_constraint = prpy.tsr.TSR(T0_w = numpy.eye(4),
-                                        Tw_e = right_in_left,
-                                        Bw = numpy.zeros((6,2)),#Bw_constrain,
-                                        manip=right_manip_idx,
-                                        bodyandlink='%s %s' % (robot.GetName(), robot.left_arm.GetEndEffector().GetName()))
-    movement_chain = prpy.tsr.TSRChain(sample_start = False, sample_goal = False, constrain=True,
+    tsr_right_constraint = TSR(T0_w = numpy.eye(4),
+                               Tw_e = right_in_left,
+                               Bw = numpy.zeros((6,2)),#Bw_constrain,
+                               manip=right_manip_idx,
+                               bodyandlink='%s %s' % (robot.GetName(), robot.left_arm.GetEndEffector().GetName()))
+    movement_chain = TSRChain(sample_start = False, sample_goal = False, constrain=True,
                               TSRs = [tsr_right_constraint, tsr_left_constraint])
     
     return [goal_tsr_chain, movement_chain] 
 
-@prpy.tsr.tsrlibrary.TSRFactory('herb', 'wicker_tray', 'pull')
+@TSRFactory('herb', 'wicker_tray', 'pull')
 def pull_tray(robot, tray, manip=None, max_distance=0.0, min_distance=0.0, 
               direction=[1., 0., 0.], angular_tolerance=[0., 0., 0.],  position_tolerance=[0., 0., 0.]):
     """
@@ -245,15 +240,15 @@ def pull_tray(robot, tray, manip=None, max_distance=0.0, min_distance=0.0,
     Bw_goal[4,:] = [-angular_tolerance[1], angular_tolerance[1]]
     Bw_goal[5,:] = [-angular_tolerance[2], angular_tolerance[2]]
     
-    goal_tsr = prpy.tsr.TSR(T0_w = desired_w_in_world,
-                            Tw_e = ee_in_w,
-                            Bw = Bw_goal,
-                            manip = manip_idx)
+    goal_tsr = TSR(T0_w = desired_w_in_world,
+                   Tw_e = ee_in_w,
+                   Bw = Bw_goal,
+                   manip = manip_idx)
 
-    goal_tsr_chain = prpy.tsr.TSRChain(sample_start=False, 
-                                       sample_goal=True, 
-                                       constrain=False,
-                                       TSRs=[goal_tsr])
+    goal_tsr_chain = TSRChain(sample_start=False, 
+                              sample_goal=True, 
+                              constrain=False,
+                              TSRs=[goal_tsr])
 
     Bw_constraint = numpy.zeros((6,2))
     Bw_constraint[0,:] = [-position_tolerance[0], position_tolerance[0]]
@@ -263,13 +258,13 @@ def pull_tray(robot, tray, manip=None, max_distance=0.0, min_distance=0.0,
     Bw_constraint[4,:] = [-angular_tolerance[1], angular_tolerance[1]]
     Bw_constraint[5,:] = [-angular_tolerance[2], angular_tolerance[2]]
 
-    traj_tsr = prpy.tsr.TSR(T0_w = w_in_world,
-                            Tw_e = ee_in_w,
-                            Bw = Bw_constraint,
-                            manip = manip_idx)
-    traj_tsr_chain = prpy.tsr.TSRChain(sample_start=False,
-                                       sample_goal=False,
-                                       constrain=True,
-                                       TSRs = [traj_tsr])
+    traj_tsr = TSR(T0_w = w_in_world,
+                   Tw_e = ee_in_w,
+                   Bw = Bw_constraint,
+                   manip = manip_idx)
+    traj_tsr_chain = TSRChain(sample_start=False,
+                              sample_goal=False,
+                              constrain=True,
+                              TSRs = [traj_tsr])
     
     return [goal_tsr_chain, traj_tsr_chain]

--- a/src/herbpy/tsr/tray.py
+++ b/src/herbpy/tsr/tray.py
@@ -22,9 +22,8 @@ def point_on(robot, tray, manip=None, padding=0.0, handle_padding=True):
     if manip is None:
         manip_idx = robot.GetActiveManipulatorIndex()
     else:
-        with manip.GetRobot():
-            manip.SetActive()
-            manip_idx = manip.GetRobot().GetActiveManipulatorIndex()
+        manip.SetActive()
+        manip_idx = manip.GetRobot().GetActiveManipulatorIndex()
             
     T0_w = tray.GetTransform()
 
@@ -210,9 +209,8 @@ def pull_tray(robot, tray, manip=None, max_distance=0.0, min_distance=0.0,
         manip = robot.GetActiveManipulator()
         manip_idx = robot.GetActiveManipulatorIndex()
     else:
-        with manip.GetRobot():
-            manip.SetActive()
-            manip_idx = manip.GetRobot().GetActiveManipulatorIndex()
+        manip.SetActive()
+        manip_idx = manip.GetRobot().GetActiveManipulatorIndex()
             
     # Create a w frame with z-axis pointing in direction of pull
     ee_in_world = manip.GetEndEffectorTransform()


### PR DESCRIPTION
Based on the discussion with @jeking04 and @mkoval, this removes all environment locking inside the TSR lib, thus placing the responsibility on the user. Coordinating with this is adding this responsibility to the action lib, that calls the TSR Lib. 

Maybe this isn't exactly what we want (or not the correct implementation of what we discussed) but I'll get the ball rolling.  