### PR TITLE
Fix the example code (Fuze bottle grasping)

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,12 +233,12 @@ robot.base.PlanToBasePose(robot_pose_in_world)
 
 ### Other Examples ###
 
-Comprehensive example of picking up a Fuze drink bottle: 
-HERB will plan a path for the Segway base using SBPL and drive to the table, grasp the object using a simulated push-grasp and lift it off the table. 
+Comprehensive example of picking up a Fuze drink bottle:  
+HERB will plan a path for the Segway base using SBPL and drive to the table, grasp the object using a simulated push-grasp and lift it off the table.  
 [examples/graspFuzeBottle.py](examples/graspFuzeBottle.py)
 
-Push-grasping example: 
-This depends on the `randomized_rearrangement_planning` package, which will be released soon, and requires OMPL from `ros-indigo-ompl` 
+Push-grasping example:  
+This depends on the `randomized_rearrangement_planning` package, which will be released soon, and requires OMPL from `ros-indigo-ompl`.  
 [examples/pushAndGraspCup.py](examples/pushAndGraspCup.py)
 
 

--- a/README.md
+++ b/README.md
@@ -233,7 +233,14 @@ robot.base.PlanToBasePose(robot_pose_in_world)
 
 ### Other Examples ###
 
-* [Comprehensive example of picking up a fuze bottle](examples/graspFuzeBottle.py)
+Comprehensive example of picking up a Fuze drink bottle: 
+HERB will plan a path for the Segway base using SBPL and drive to the table, grasp the object using a simulated push-grasp and lift it off the table. 
+* [examples/graspFuzeBottle.py](examples/graspFuzeBottle.py)
+
+Push-grasping example: 
+This depends on the `randomized_rearrangement_planning` package, which will be released soon, and requires OMPL from `ros-indigo-ompl`
+* [examples/pushAndGraspCup.py](examples/pushAndGraspCup.py)
+
 
 [herbpy.herb.initialize]: src/herbpy/herb.py#L7
 [console.py]: scripts/console.py

--- a/README.md
+++ b/README.md
@@ -235,11 +235,11 @@ robot.base.PlanToBasePose(robot_pose_in_world)
 
 Comprehensive example of picking up a Fuze drink bottle: 
 HERB will plan a path for the Segway base using SBPL and drive to the table, grasp the object using a simulated push-grasp and lift it off the table. 
-* [examples/graspFuzeBottle.py](examples/graspFuzeBottle.py)
+[examples/graspFuzeBottle.py](examples/graspFuzeBottle.py)
 
 Push-grasping example: 
-This depends on the `randomized_rearrangement_planning` package, which will be released soon, and requires OMPL from `ros-indigo-ompl`
-* [examples/pushAndGraspCup.py](examples/pushAndGraspCup.py)
+This depends on the `randomized_rearrangement_planning` package, which will be released soon, and requires OMPL from `ros-indigo-ompl` 
+[examples/pushAndGraspCup.py](examples/pushAndGraspCup.py)
 
 
 [herbpy.herb.initialize]: src/herbpy/herb.py#L7

--- a/examples/graspFuzeBottle.py
+++ b/examples/graspFuzeBottle.py
@@ -1,19 +1,28 @@
+#!/usr/bin/env python
+
 import herbpy
 import os
 import numpy
 import math
 import openravepy
+import sys # exit()
 
 # get the location of some objects (you'll need the pr_ordata package)
 from catkin.find_in_workspaces import find_in_workspaces
+package_name = 'pr_ordata'
+directory = 'data/objects'
 objects_path = find_in_workspaces(
     search_dirs=['share'],
-    project='pr_ordata',
-    path='data/objects',
-    first_match_only=True)[0]
+    project=package_name,
+    path=directory,
+    first_match_only=True)
+if len(objects_path) == 0:
+    print('Can\'t find directory %s/%s' % (package_name, directory))
+    sys.exit()
+else:
+    print objects_path # for me this is '/home/USERNAME/catkin_workspaces/herb_ws/src/pr-ordata/data/objects'
+    objects_path = objects_path[0]
 
-
-print objects_path # for me this is '/home/eashapir/ros-hydro/src/pr-ordata/data/objects'
 
 # ===========================
 #   ENVIRONMENT SETUP
@@ -24,6 +33,9 @@ env, robot = herbpy.initialize(sim=True, attach_viewer='rviz')
 # add a table to the environment
 table_file = os.path.join(objects_path, 'table.kinbody.xml')
 table = env.ReadKinBodyXMLFile(table_file)
+if table == None:
+    print('Failed to load table kinbody')
+    sys.exit()
 env.AddKinBody(table)
 table_pose = numpy.array([[1., 0.,  0., 2],
                     [0., 0., -1., 2],
@@ -34,6 +46,9 @@ table.SetTransform(table_pose)
 # add a fuze bottle on top of the table
 fuze_path = os.path.join(objects_path, 'fuze_bottle.kinbody.xml')
 fuze = env.ReadKinBodyXMLFile(fuze_path)
+if fuze == None:
+    print('Failed to load fuze bottle kinbody')
+    sys.exit()
 table_aabb = table.ComputeAABB()
 x = table_aabb.pos()[0] + table_aabb.extents()[0]*0 # middle of table in x
 y = table_aabb.pos()[1] + table_aabb.extents()[1]*.6 # closer to one side of table in y
@@ -67,7 +82,8 @@ robot.base.PlanToBasePose(base_pose)
 
 # Grasp the bottle
 robot.right_arm.PushGrasp(fuze, push_required=False)
-robot.right_arm.PlanToNamedConfiguration('home')
+robot.right_arm.PlanToNamedConfiguration('home', execute=True)
+
 
 # we do this so the viewer doesn't close when the example is done
 import IPython; IPython.embed()


### PR DESCRIPTION
This fixes the 1st example code:
 - PlanToNamedConfiguration() requires a new flag "execute=True"
 - Add some error messages for path finding and kinbody loading

The 2nd example depends on another stack of packages, so I don't know if it still works.

Updated the README.

