### PR TITLE
Changed DetectObjects() default params

### DIFF
--- a/src/herbpy/herbrobot.py
+++ b/src/herbpy/herbrobot.py
@@ -193,7 +193,8 @@ class HERBRobot(Robot):
                                                 marker_data_path=marker_data_path,
                                                 kinbody_path=kinbody_path,
                                                 detection_frame='head/kinect2_rgb_optical_frame',
-                                                destination_frame='map')
+                                                destination_frame='herb_base',
+                                                reference_link=self.GetLink('/herb_base'))
             except IOError as e:
                  logger.warning('Failed to find required resource path. ' \
                                 'pr-ordata package cannot be found. ' \


### PR DESCRIPTION
Default usage of `DetectObjects()` is to call AprilTags with reference link as `herb_base`