### PR TITLE
Modified RoGuE to use prpy.util.GetPointFrom

### DIFF
--- a/src/herbpy/action/rogue.py
+++ b/src/herbpy/action/rogue.py
@@ -2,7 +2,7 @@ import logging, openravepy, prpy
 from prpy.action import ActionMethod
 from prpy.planning.base import PlanningError
 from contextlib import contextmanager 
-from prpy.util import FindCatkinResource
+from prpy.util import FindCatkinResource, GetPointFrom
 import numpy, cPickle, time, os.path
 
 logger = logging.getLogger('herbpy')
@@ -18,7 +18,7 @@ def PointAt(robot, focus, manip=None, render=False):
     @param render Render tsr samples during planning
     """
     env = robot.GetEnv()
-    pointing_coord = GetPointFrom(env, focus)
+    pointing_coord = GetPointFrom(focus)
     return Point(robot, pointing_coord, manip, render)
 
 @ActionMethod
@@ -32,7 +32,7 @@ def PresentAt(robot, focus, manip=None, render=True):
     @param render Render tsr samples during planning
     """
     env = robot.GetEnv()
-    presenting_coord = GetPointFrom(env, focus)
+    presenting_coord = GetPointFrom(focus)
     return Present(robot, presenting_coord, manip, render)
 
 @ActionMethod
@@ -48,40 +48,9 @@ def SweepAt(robot, start, end, manip=None, margin=0.3, render=True):
     @param render Render tsr samples during planning
     """
     env = robot.GetEnv()
-    start_coord = GetPointFrom(env, start)
-    end_coord = GetPointFrom(env, end)
+    start_coord = GetPointFrom(start)
+    end_coord = GetPointFrom(end)
     return Sweep(robot, start_coord, end_coord, manip, margin, render)
-
-
-def GetPointFrom(env, focus):
-    """
-    @param env The environment where the item exists
-    @param focus The area to be referred to
-    """
-    #Pointing at an object
-    if isinstance(focus, (openravepy.KinBody, openravepy.KinBody.Link)):
-        with env: 
-            focus_trans = focus.GetTransform()
-        coord = list(focus_trans[0:3, 3])
-
-    #Pointing at a point in space as numpy array
-    elif (isinstance(focus, numpy.ndarray) and (focus.ndim == 1) 
-           and (len(focus) == 3)):
-        coord = list(focus)
-
-    #Pointing at point in space as 4x4 transform
-    elif isinstance(focus, numpy.ndarray) and (focus.shape == (4, 4)):
-        coord = list(focus[0:3, 3])
-
-    #Pointing at a point in space as list or tuple
-    elif (isinstance(focus, (tuple, list)) and len(focus) == 3):
-        coord = focus
-
-    else:
-        raise prpy.exceptions.PrPyException('Focus of the point is an \
-                unknown object')
-
-    return coord
 
 def Point(robot, coord, manip=None, render=False):
     """

--- a/src/herbpy/action/rogue.py
+++ b/src/herbpy/action/rogue.py
@@ -17,7 +17,6 @@ def PointAt(robot, focus, manip=None, render=False):
                  This must be the right arm
     @param render Render tsr samples during planning
     """
-    env = robot.GetEnv()
     pointing_coord = GetPointFrom(focus)
     return Point(robot, pointing_coord, manip, render)
 
@@ -31,7 +30,6 @@ def PresentAt(robot, focus, manip=None, render=True):
                  This must be the right arm.
     @param render Render tsr samples during planning
     """
-    env = robot.GetEnv()
     presenting_coord = GetPointFrom(focus)
     return Present(robot, presenting_coord, manip, render)
 
@@ -47,7 +45,6 @@ def SweepAt(robot, start, end, manip=None, margin=0.3, render=True):
                   This must be enough to clear the objects themselves.
     @param render Render tsr samples during planning
     """
-    env = robot.GetEnv()
     start_coord = GetPointFrom(start)
     end_coord = GetPointFrom(end)
     return Sweep(robot, start_coord, end_coord, manip, margin, render)

--- a/tests/rogue_tests.py
+++ b/tests/rogue_tests.py
@@ -29,22 +29,22 @@ class RogueTest(unittest.TestCase):
         herbpy.action.Sweep(self.robot, [0.7, 0, 0.5], [0.5, 0, 0.5])
 
     def test_GetPointFrom(self):
-        kinbody_coord = herbpy.action.GetPointFrom(self.env, self.fuze)
+        kinbody_coord = prpy.util.GetPointFrom(self.fuze)
         numpy.testing.assert_almost_equal(kinbody_coord, self.fuze_pose[0:3, 3])
 
         test_array = numpy.array([0, 1, 2])
-        numpyarray_coord = herbpy.action.GetPointFrom(self.env, test_array)
+        numpyarray_coord = prpy.util.GetPointFrom(test_array)
         numpy.testing.assert_almost_equal(numpyarray_coord, test_array)
 
         test_list = [0, 1, 2]
-        list_coord = herbpy.action.GetPointFrom(self.env, test_list)
+        list_coord = prpy.util.GetPointFrom(test_list)
         numpy.testing.assert_almost_equal(list_coord, test_list)
 
         test_tuple = (0, 1, 2)
-        tuple_coord = herbpy.action.GetPointFrom(self.env, test_tuple)
+        tuple_coord = prpy.util.GetPointFrom(test_tuple)
         numpy.testing.assert_almost_equal(tuple_coord, test_tuple)
 
-        transform_coord = herbpy.action.GetPointFrom(self.env, self.fuze_pose)
+        transform_coord = prpy.util.GetPointFrom(self.fuze_pose)
         numpy.testing.assert_almost_equal(transform_coord, self.fuze_pose[0:3, 3])
 
     def test_Exhibiting(self):


### PR DESCRIPTION
We moved the functionality of 'GetPointFrom' from a function in herbpy to a util in prpy. So this PR is simply to remove that code from herbpy and switch it to calling the util funciton, which has already been merged in. 