### PR TITLE
Added yaw_range parameter to glass grasps

### DIFF
--- a/src/herbpy/action/grasping.py
+++ b/src/herbpy/action/grasping.py
@@ -24,7 +24,7 @@ def Grasp(robot, obj, manip=None, preshape=[0., 0., 0., 0.],
 @ActionMethod
 def PushGrasp(robot, obj, push_distance=0.1, manip=None, 
               preshape=[0., 0., 0., 0.], push_required=True, 
-              tsrlist=None, render=True, **kw_args):
+              yaw_range=None,tsrlist=None, render=True, **kw_args):
     """
     @param robot The robot performing the push grasp
     @param obj The object to push grasp
@@ -34,6 +34,7 @@ def PushGrasp(robot, obj, push_distance=0.1, manip=None,
     @param push_required If true, throw exception if a plan for the pushing 
        movement cannot be found. If false, continue with grasp even if push 
        cannot be executed.
+    @param yaw_range Allowable range of yaw around cup (default [-pi,pi])
     @param preshape The grasp preshape for the hand
     @param tsrlist A list of TSRChain objects to use for planning to grasp pose
        (if None, the 'grasp' tsr from tsrlibrary is used)
@@ -41,10 +42,11 @@ def PushGrasp(robot, obj, push_distance=0.1, manip=None,
     """
     with robot.GetEnv(): 
         if tsrlist is None:
-            tsrlist = robot.tsrlibrary(obj, 'push_grasp', push_distance=push_distance)
+            tsrlist = robot.tsrlibrary(obj, 'push_grasp', yaw_range=yaw_range,
+                                       push_distance=push_distance)
 
     HerbGrasp(robot, obj, manip=manip, preshape=preshape, 
-              push_distance=push_distance,
+              push_distance=push_distance, yaw_range=yaw_range,
               tsrlist=tsrlist, render=render,**kw_args)
 
 def HerbGrasp(robot, obj, push_distance=None, manip=None, 

--- a/src/herbpy/action/stacking.py
+++ b/src/herbpy/action/stacking.py
@@ -24,14 +24,12 @@ def StackCups(robot, table, cup, stack, cups_stacked, manip=None):
 
     cup_in_herb = numpy.dot(numpy.linalg.inv(herb_in_world), cup_in_world)
     theta = numpy.arctan2(cup_in_herb[1,0], cup_in_herb[0,0])
-
     if manip == robot.left_arm:    
-        yaw_in_herb = numpy.array([0, numpy.pi])
+        yaw_in_herb = numpy.array([-numpy.pi, 0])
     else:
-        yaw_in_herb = numpy.array([-numpy.pi, 0])   
-    
-    yaw_in_cup = yaw_in_herb - theta
+        yaw_in_herb = numpy.array([0, numpy.pi])   
 
+    yaw_in_cup = yaw_in_herb - theta
     robot.PushGrasp(cup, yaw_range=yaw_in_cup)
 
     from prpy.rave import Disabled

--- a/src/herbpy/tsr/glass.py
+++ b/src/herbpy/tsr/glass.py
@@ -3,17 +3,18 @@ from prpy.tsr.tsrlibrary import TSRFactory
 from prpy.tsr.tsr import TSR, TSRChain
 
 @TSRFactory('herb', 'plastic_glass', 'grasp')
-def glass_grasp(robot, glass, manip=None, **kw_args):
+def glass_grasp(robot, glass, manip=None, yaw_range=None, **kw_args):
     '''
     @param robot The robot performing the grasp
     @param glass The glass to grasp
     @param manip The manipulator to perform the grasp, if None
        the active manipulator on the robot is used
+    @param yaw_range Allowable range of yaw around cup (default [-pi,pi])
     '''
-    return _glass_grasp(robot, glass, manip=manip, **kw_args)
+    return _glass_grasp(robot, glass, manip=manip, yaw_range=yaw_range, **kw_args)
     
 @TSRFactory('herb', 'plastic_glass', 'push_grasp')
-def glass_push_grasp(robot, glass, manip=None, push_distance=0.1, **kw_args):
+def glass_push_grasp(robot, glass, manip=None, yaw_range=None, push_distance=0.1, **kw_args):
     '''
     This factory differes from glass_grasp in that it places the manipulator 
     further away and assumes the manip will perform a push after
@@ -27,16 +28,18 @@ def glass_push_grasp(robot, glass, manip=None, push_distance=0.1, **kw_args):
     @param glass The glass to grasp
     @param manip The manipulator to perform the grasp, if None
        the active manipulator on the robot is used
+    @param yaw_range Allowable range of yaw around cup (default [-pi,pi])
     @param push_distance The offset distance for pushing
     '''
-    return _glass_grasp(robot, glass, manip=manip, push_distance=push_distance, **kw_args)
+    return _glass_grasp(robot, glass, manip=manip, yaw_range=yaw_range, push_distance=push_distance, **kw_args)
 
-def _glass_grasp(robot, glass, manip=None, push_distance=0.0, **kw_args):
+def _glass_grasp(robot, glass, manip=None, yaw_range=None, push_distance=0.0, **kw_args):
     """
     @param robot The robot performing the grasp
     @param glass The glass to grasp
     @param manip The manipulator to perform the grasp, if None
        the active manipulator on the robot is used
+    @param yaw_range Allowable range of yaw around cup (default [-pi,pi])
     @param push_distance The offset distance for pushing
     """
     if manip is None:
@@ -57,7 +60,10 @@ def _glass_grasp(robot, glass, manip=None, push_distance=0.0, **kw_args):
 
     Bw = numpy.zeros((6,2))
     Bw[2,:] = [0.0, 0.02]  # Allow a little vertical movement
-    Bw[5,:] = [-numpy.pi, numpy.pi]  # Allow any orientation
+    if yaw_range is None:
+        Bw[5,:] = [-numpy.pi, numpy.pi]  # Allow any orientation
+    else:
+        Bw[5,:] = yaw_range
     
     grasp_tsr = TSR(T0_w = T0_w, Tw_e = Tw_e, Bw = Bw, manip = manip_idx)
     grasp_chain = TSRChain(sample_start=False, sample_goal = True, 

--- a/src/herbpy/tsr/pitcher.py
+++ b/src/herbpy/tsr/pitcher.py
@@ -4,7 +4,7 @@ from prpy.tsr.tsrlibrary import TSRFactory
 from prpy.tsr.tsr import TSR, TSRChain
       
 @TSRFactory('herb', 'rubbermaid_ice_guard_pitcher', 'push_grasp')
-def pitcher_grasp(robot, pitcher, push_distance=0.1, manip=None):
+def pitcher_grasp(robot, pitcher, push_distance=0.1, manip=None, **kw_args):
 
     '''
     @param robot The robot performing the grasp
@@ -53,7 +53,7 @@ def pitcher_grasp(robot, pitcher, push_distance=0.1, manip=None):
         
 @TSRFactory('herb', 'rubbermaid_ice_guard_pitcher', 'pour')
 def pitcher_pour(robot, pitcher, min_tilt = 1.4, max_tilt = 1.57, manip=None, grasp_transform = None, 
-                 pitcher_pose = None):
+                 pitcher_pose = None, **kw_args):
     '''
     @param robot The robot whose active manipulator should be used to pour
     @param pitcher The pitcher to pour


### PR DESCRIPTION
I added yaw_range to the glass grasping TSRs and the PushGrasp function. If no yaw_range is given the default is [-numpy.pi, numpy.pi]. I also, added **kw_args to pitcher.py. 