### PR TITLE
Determine correct hand DOF indices and Open/Close behavior

### DIFF
--- a/src/herbpy/barretthand.py
+++ b/src/herbpy/barretthand.py
@@ -109,7 +109,7 @@ class BarrettHand(EndEffector):
         order: [ finger 0, finger 1, finger 2, spread ].
         @return DOF indices of the hand
         """
-        return [self.GetSpreadIndex()] + self.GetFingerIndices()
+        return self.GetFingerIndices() + [self.GetSpreadIndex()]
 
     def MoveHand(self, f1=None, f2=None, f3=None, spread=None, timeout=None):
         """Change the hand preshape.
@@ -129,23 +129,15 @@ class BarrettHand(EndEffector):
         preshape = [None]*4
         # Set control command and
         # default any None's to the current DOF values.
-        if self.simulated:
-            preshape[0] = spread if spread is not None else curr_pos[0]
-            preshape[1] = f1 if f1 is not None else curr_pos[1]
-            preshape[2] = f2 if f2 is not None else curr_pos[2]
-            preshape[3] = f3 if f3 is not None else curr_pos[3]
-        else:
-            # TODO when PositionCommandController is updated to index by
-            # joint name, this special logic can be removed
-            preshape[0] = f1 if f1 is not None else curr_pos[1]
-            preshape[1] = f2 if f2 is not None else curr_pos[2]
-            preshape[2] = f3 if f3 is not None else curr_pos[3]
-            preshape[3] = spread if spread is not None else curr_pos[0]
+        preshape[0] = f1 if f1 is not None else curr_pos[1]
+        preshape[1] = f2 if f2 is not None else curr_pos[2]
+        preshape[2] = f3 if f3 is not None else curr_pos[3]
+        preshape[3] = spread if spread is not None else curr_pos[0]
 
         self.controller.SetDesired(preshape)
         util.WaitForControllers([ self.controller ], timeout=timeout)
 
-    def OpenHand(hand, spread=0.0, timeout=None):
+    def OpenHand(hand, spread=None, timeout=None):
         """Open the hand with a fixed spread.
         This function blocks until the hand has reached the desired
         configuration or a timeout occurs. Specifying a timeout of a finishes.

--- a/src/herbpy/barretthand.py
+++ b/src/herbpy/barretthand.py
@@ -125,12 +125,22 @@ class BarrettHand(EndEffector):
         @param spread spread angle, in radians
         @param timeout blocking execution timeout, in seconds
         """
-        # Default any None's to the current DOF values.
-        preshape = self.GetDOFValues()
-        if f1     is not None: preshape[0] = f1
-        if f2     is not None: preshape[1] = f2
-        if f3     is not None: preshape[2] = f3
-        if spread is not None: preshape[3] = spread
+        curr_pos = self.GetDOFValues()
+        preshape = [None]*4
+        # Set control command and
+        # default any None's to the current DOF values.
+        if self.simulated:
+            preshape[0] = spread if spread is not None else curr_pos[0]
+            preshape[1] = f1 if f1 is not None else curr_pos[1]
+            preshape[2] = f2 if f2 is not None else curr_pos[2]
+            preshape[3] = f3 if f3 is not None else curr_pos[3]
+        else:
+            # TODO when PositionCommandController is updated to index by
+            # joint name, this special logic can be removed
+            preshape[0] = f1 if f1 is not None else curr_pos[1]
+            preshape[1] = f2 if f2 is not None else curr_pos[2]
+            preshape[2] = f3 if f3 is not None else curr_pos[3]
+            preshape[3] = spread if spread is not None else curr_pos[0]
 
         self.controller.SetDesired(preshape)
         util.WaitForControllers([ self.controller ], timeout=timeout)

--- a/src/herbpy/barretthand.py
+++ b/src/herbpy/barretthand.py
@@ -109,7 +109,7 @@ class BarrettHand(EndEffector):
         order: [ finger 0, finger 1, finger 2, spread ].
         @return DOF indices of the hand
         """
-        return [ self.GetSpreadIndex() ] + self.GetFingerIndices()
+        return [self.GetSpreadIndex()] + self.GetFingerIndices()
 
     def MoveHand(self, f1=None, f2=None, f3=None, spread=None, timeout=None):
         """Change the hand preshape.
@@ -135,7 +135,7 @@ class BarrettHand(EndEffector):
         self.controller.SetDesired(preshape)
         util.WaitForControllers([ self.controller ], timeout=timeout)
 
-    def OpenHand(hand, spread=None, timeout=None):
+    def OpenHand(hand, spread=0.0, timeout=None):
         """Open the hand with a fixed spread.
         This function blocks until the hand has reached the desired
         configuration or a timeout occurs. Specifying a timeout of a finishes.

--- a/tests/hand_tests.py
+++ b/tests/hand_tests.py
@@ -1,25 +1,24 @@
-#!/usr/bin/env python
-PKG = 'herbpy'
-import roslib; roslib.load_manifest(PKG)
-import numpy, unittest
 import herbpy
+import numpy
+import unittest
 
 env, robot = herbpy.initialize(sim=True)
+
 
 class BarrettHandTest(unittest.TestCase):
     def setUp(self):
         self._env, self._robot = env, robot
         self._wam = robot.right_arm
         self._hand = self._wam.hand
-        self._indices = numpy.array(self._wam.GetChildDOFIndices())
+        self._indices = numpy.array(sorted(self._wam.GetChildDOFIndices()))
         self._num_dofs = len(self._indices)
 
     def test_GetIndices_ReturnsIndices(self):
-        # TODO what is this actually testing? Consistency w/ OpenRAVE?
-        numpy.testing.assert_array_equal(self._hand.GetIndices(), self._indices)
+        numpy.testing.assert_array_equal(
+            sorted(self._hand.GetIndices()), self._indices)
 
     def test_GetDOFValues_SetsValues(self):
-        expected_values = numpy.array([ 0.1, 0.2, 0.3, 0.4 ])
+        expected_values = numpy.array([0.1, 0.2, 0.3, 0.4])
         self._robot.SetDOFValues(expected_values, self._indices)
         numpy.testing.assert_array_almost_equal(self._hand.GetDOFValues(), expected_values)
 
@@ -55,15 +54,9 @@ class BarrettHandTest(unittest.TestCase):
 
     def test_MoveHand_MovesAllFingers(self):
         before = numpy.zeros(self._num_dofs)
-        after = numpy.zeros(self._num_dofs)
-        for i in xrange(self._num_dofs):
-            after[i] = 0.5
+        after = numpy.arange(self._num_dofs)
 
         self._robot.SetDOFValues(before, self._indices)
         self._hand.MoveHand(*after)
         self._robot.WaitForController(0)
         numpy.testing.assert_array_almost_equal(self._robot.GetDOFValues(self._indices), after)
-
-if __name__ == '__main__':
-    import rosunit
-    rosunit.unitrun(PKG, 'test_hand', BarrettHandTest)


### PR DESCRIPTION
During the ros_control upgrade I noticed `hand_tests::test_getIndices_ReturnsIndices` fails, so I changed the order of spread/fingers in `Hand::GetIndices` (intentionally highlighted line 112 below) to make the test pass. This has broken some other code, and seems to not match the Barrett (and others'?) convention of spread being last.

This commit so far is just to make OpenHand move to the expected open position, with spread at `0.0`.

@mkoval @psigen @cdellin Can we use this PR to determine the correct way this should all work?