### PR TITLE
Load HERB model from parameter server in non-sim

### DIFF
--- a/src/herbpy/barretthand.py
+++ b/src/herbpy/barretthand.py
@@ -251,3 +251,13 @@ class BarrettHand(EndEffector):
         robot = self.manipulator.GetRobot()
         full_name = '/{:s}/{:s}'.format(self.manipulator.GetName(), name)
         return robot.GetJoint(full_name)
+
+
+def EndEffectorIsBarrettHand(manipulator):
+    """Dynamically determine if loaded endeffector is a BarrettHand"""
+    robot = manipulator.GetRobot()
+    test_joints = ['j00', 'j01', 'j11', 'j21']
+    has_joint = [robot.GetJoint('/{:s}/{:s}'.format(
+        manipulator.GetName(), jnt)) is not None for jnt in test_joints]
+    has_all_joints = all(has_joint)
+    return has_all_joints

--- a/src/herbpy/herb.py
+++ b/src/herbpy/herb.py
@@ -46,7 +46,6 @@ def initialize(robot_xml=None, env_path=None, attach_viewer=False,
         herb_name = urdf_module.SendCommand(args)
     else:
         import rospy
-        rospy.init_node('herbpy_testing')  # TODO rm
         if not rospy.core.is_initialized():
             raise RuntimeError('rospy not initialized. '
                                'Must call rospy.init_node()')

--- a/src/herbpy/herb.py
+++ b/src/herbpy/herb.py
@@ -42,7 +42,7 @@ def initialize(robot_xml=None, env_path=None, attach_viewer=False,
     if sim:
         urdf_uri = 'package://herb_description/robots/herb.urdf'
         srdf_uri = 'package://herb_description/robots/herb.srdf'
-        args = 'Load {:s} {:s}'.format(urdf_uri, srdf_uri)
+        args = 'LoadURI {:s} {:s}'.format(urdf_uri, srdf_uri)
         herb_name = urdf_module.SendCommand(args)
     else:
         import rospy
@@ -60,7 +60,7 @@ def initialize(robot_xml=None, env_path=None, attach_viewer=False,
         urdf_json_wrapper = json.dumps(
             {'urdf': urdf_string.replace('\n', ' ').replace('\r', ' '),
              'srdf': srdf_string.replace('\n', ' ').replace('\r', ' ')})
-        args = 'LoadJsonString {}'.format(urdf_json_wrapper)
+        args = 'LoadString {}'.format(urdf_json_wrapper)
         herb_name = urdf_module.SendCommand(args)
 
     if herb_name is None:


### PR DESCRIPTION
To support multiple arm/hand configurations, load the HERB urdf/srdf from `/robot_description` and `/semantic_robot_description`. Additionally, need to test the end effectors to determine if they are BarrettHands or dummy EEs.

Depends on https://github.com/personalrobotics/or_urdf/pull/26 and https://github.com/personalrobotics/prpy/pull/346
