### PR TITLE
Re-implement MoveUntilTouch

### DIFF
--- a/config/barrett_preshapes.yaml
+++ b/config/barrett_preshapes.yaml
@@ -13,3 +13,8 @@ configurations:
         hand: [0.684, 0.684, 0.684, 0.0]
     plate_grasp:
         hand: [0.976, 0.976, 0.976, 0.0]
+    block_grasp_preshape:
+        hand: [1.7, 1.7, 0.2, 2.45]
+    block_grasp:
+        hand: [1.7, 1.7, 1.7, 2.45]
+    

--- a/scripts/move_until_touch.py
+++ b/scripts/move_until_touch.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python
+"""
+Provides a simple console that sets up basic functionality for 
+using herbpy and openravepy.
+"""
+
+import os
+if os.environ.get('ROS_DISTRO', 'hydro')[0] <= 'f':
+    import roslib
+    roslib.load_manifest('herbpy')
+
+import argparse, herbpy, logging, numpy, openravepy, sys
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description='utility script for loading HerbPy')
+    parser.add_argument('-s', '--sim', action='store_true',
+                        help='simulation mode')
+    parser.add_argument('-v', '--viewer', nargs='?', const=True,
+                        help='attach a viewer of the specified type')
+    parser.add_argument('--robot-xml', type=str,
+                        help='robot XML file; defaults to herb_description')
+    parser.add_argument('--env-xml', type=str,
+                        help='environment XML file; defaults to an empty environment')
+    parser.add_argument('-b', '--segway-sim', action='store_true',
+                        help='simulate base')
+    parser.add_argument('-p', '--perception-sim', action='store_true',
+                        help='simulate perception')
+    parser.add_argument('--debug', action='store_true',
+                        help='enable debug logging')
+    args = parser.parse_args()
+
+    openravepy.RaveInitialize(True)
+    openravepy.misc.InitOpenRAVELogging()
+
+    if args.debug:
+        openravepy.RaveSetDebugLevel(openravepy.DebugLevel.Debug)
+
+    herbpy_args = {'sim':args.sim,
+                   'attach_viewer':args.viewer,
+                   'robot_xml':args.robot_xml,
+                   'env_path':args.env_xml,
+                   'left_hand_sim':True,
+                   'left_ft_sim':True,
+                   'left_arm_sim':True,
+                   'segway_sim':args.segway_sim,
+                   'perception_sim': args.perception_sim}
+    if not args.sim:
+        import rospy
+        rospy.init_node('herbpy')
+
+    if args.sim and not args.segway_sim:
+        herbpy_args['segway_sim'] = args.sim
+    
+    env, robot = herbpy.initialize(**herbpy_args)
+    
+    robot.right_hand.MoveHand(0.8, 0.8, 0.8)
+    robot.right_arm.SetStiffness(0)
+    raw_input('move hand into position then press [Return]')
+    robot.right_arm.SetStiffness(1)
+    robot.right_arm.MoveUntilTouch([0,0,-1], 0.2, 0.25, max_force=10.0, max_torque=0.6, execute=True)
+

--- a/src/herbpy/herb.py
+++ b/src/herbpy/herb.py
@@ -45,7 +45,7 @@ def initialize(robot_xml=None, env_path=None, attach_viewer=False,
 
     urdf_uri = 'package://herb_description/robots/herb.urdf'
     srdf_uri = 'package://herb_description/robots/herb.srdf'
-    args = 'Load {:s} {:s}'.format(urdf_uri, srdf_uri)
+    args = 'LoadURI {:s} {:s}'.format(urdf_uri, srdf_uri)
     herb_name = urdf_module.SendCommand(args)
     if herb_name is None:
         raise ValueError('Failed loading HERB model using or_urdf.')

--- a/src/herbpy/herbrobot.py
+++ b/src/herbpy/herbrobot.py
@@ -355,14 +355,28 @@ class HERBRobot(Robot):
         else:
             if self.right_arm in traj_manipulators:
                 if not self.right_arm.IsSimulated():
-                    if not move_until_touch:
+                    if move_until_touch:
+                        # controller alread started, just connect directly
+                        active_controllers.append(
+                            RewdOrTrajectoryController(
+                                self, '',
+                                'right_move_until_touch_controller',
+                                self.right_arm.GetJointNames()))
+                    else:
                         controllers_manip.append('right_trajectory_controller')
                 else:
                     active_controllers.append(self.right_arm.sim_controller)
 
             if self.left_arm in traj_manipulators:
                 if not self.left_arm.IsSimulated():
-                    if not move_until_touch:
+                    if move_until_touch:
+                        # controller alread started, just connect directly
+                        active_controllers.append(
+                            RewdOrTrajectoryController(
+                                self, '',
+                                'left_move_until_touch_controller',
+                                self.left_arm.GetJointNames()))
+                    else:
                         controllers_manip.append('left_trajectory_controller')
                 else:
                     active_controllers.append(self.left_arm.sim_controller)
@@ -388,25 +402,11 @@ class HERBRobot(Robot):
                                                'right_trajectory_controller',
                                                self.right_arm.GetJointNames()))
 
-            if 'right_move_until_touch_controller' in controllers_manip:
-                active_controllers.append(
-                    RewdOrTrajectoryController(
-                        self, '',
-                        'right_move_until_touch_controller',
-                        self.right_arm.GetJointNames()))
-
             if 'left_trajectory_controller' in controllers_manip:
                 active_controllers.append(
                     RewdOrTrajectoryController(self, '',
                                                'left_trajectory_controller',
                                                self.left_arm.GetJointNames()))
-
-            if 'left_move_until_touch_controller' in controllers_manip:
-                active_controllers.append(
-                    RewdOrTrajectoryController(
-                        self, '',
-                        'left_move_until_touch_controller',
-                        self.left_arm.GetJointNames()))
 
         if needs_base:
             if (hasattr(self, 'base') and hasattr(self.base, 'controller') and
@@ -424,8 +424,6 @@ class HERBRobot(Robot):
         return traj
 
     def ExecuteTrajectory(self, traj, *args, **kwargs):
-        # from prpy.exceptions import TrajectoryAborted
-
         value = self._ExecuteTrajectory(traj, *args, **kwargs)
 
         # TODO meaningful to do this check here?

--- a/src/herbpy/tsr/block.py
+++ b/src/herbpy/tsr/block.py
@@ -40,7 +40,7 @@ def block_grasp(robot, block, manip=None, **kw_args):
                               TSRs = [pose_tsr])
     return [pose_tsr_chain]
             
-@TSRFactory('herb', 'block', 'place')
+@TSRFactory('herb', 'block', 'place_at')
 def block_at_pose(robot, block, position, manip=None):
     '''
     Generates end-effector poses for placing the block on another object
@@ -82,7 +82,7 @@ def block_at_pose(robot, block, position, manip=None):
                                TSRs = [place_tsr, ee_tsr])
     return [place_tsr_chain]
 
-@TSRFactory('herb', 'block', 'place_on')        
+@TSRFactory('herb', 'block', 'place')        
 def block_on_surface(robot, block, pose_tsr_chain, manip=None):
     '''
     Generates end-effector poses for placing the block on a surface.

--- a/src/herbpy/wam.py
+++ b/src/herbpy/wam.py
@@ -314,7 +314,11 @@ class WAM(Manipulator):
 
             # execute movement
             kw_args['move_until_touch'] = True
-            traj = robot.ExecutePath(path, execute=execute, **kw_args)
+            with robot.CreateRobotStateSaver(
+                    Robot.SaveParameters.JointMaxVelocityAndAcceleration):
+                vl = robot.GetDOFVelocityLimits()
+                self.SetVelocityLimits(velocity_limit_scale*vl, 0.5)
+                traj = robot.ExecutePath(path, execute=execute, **kw_args)
             self.SetStiffness(True)
             return traj
 


### PR DESCRIPTION
Requires https://github.com/personalrobotics/rewd_controllers/pull/5 and https://github.com/personalrobotics/pr_control_msgs/pull/1.

Fixes `wam.MoveUntilTouch` to work with the new controller, while following the original API. Tested working on HERB. Also includes a simple script to just run MoveUntilTouch directly after positioning end-effector by hand.
