### PR TITLE
disable check that herb is extremely close to traj start position

### DIFF
--- a/src/herbpy/herbrobot.py
+++ b/src/herbpy/herbrobot.py
@@ -311,9 +311,9 @@ class HERBRobot(Robot):
 
         # Check that the current configuration of the robot matches the
         # initial configuration specified by the trajectory.
-        if not prpy.util.IsAtTrajectoryStart(self, traj):
-            raise TrajectoryNotExecutable(
-                'Trajectory started from different configuration than robot.')
+        # if not prpy.util.IsAtTrajectoryStart(self, traj):
+        #     raise TrajectoryNotExecutable(
+        #         'Trajectory started from different configuration than robot.')
 
         # If there was only one waypoint, at this point we are done!
         if traj.GetNumWaypoints() == 1:


### PR DESCRIPTION
Because OWD published last commanded position, not actual position,
but ros_control and rewd_controllers publish actual position,
the check in herbpy that current position is extremely close to the
planning start position almost always fails.

However, this has not been a problem in practice, and we have been
running with this code commented out for over a month.

Do we want to change the tolerance, or delete this check?