### PR TITLE
For usage after splitting out TSR from prpy

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -34,6 +34,7 @@
   <exec_depend>or_sbpl</exec_depend>
   <exec_depend>openrave</exec_depend>
   <exec_depend>python-yaml</exec_depend>
+  <exec_depend>tsr</exec_depend>
 
   <test_depend>actionlib</test_depend>
   <test_depend>actionlib_msgs</test_depend>
@@ -52,6 +53,7 @@
   <test_depend>or_sbpl</test_depend>
   <test_depend>openrave</test_depend>
   <test_depend>python-yaml</test_depend>
+  <test_depend>tsr</test_depend>
 
   <test_depend>python-nose</test_depend>
   <test_depend>pr_ordata</test_depend>

--- a/src/herbpy/tsr/block.py
+++ b/src/herbpy/tsr/block.py
@@ -1,6 +1,6 @@
 import numpy
-from prpy.tsr.tsrlibrary import TSRFactory
-from prpy.tsr.tsr import TSR, TSRChain
+from tsr.tsrlibrary import TSRFactory
+from tsr.tsr import TSR, TSRChain
 
 @TSRFactory('herb', 'block', 'grasp')
 def block_grasp(robot, block, manip=None, **kw_args):

--- a/src/herbpy/tsr/block_bin.py
+++ b/src/herbpy/tsr/block_bin.py
@@ -1,6 +1,6 @@
 import numpy
-from prpy.tsr.tsrlibrary import TSRFactory
-from prpy.tsr.tsr import TSR, TSRChain
+from tsr.tsrlibrary import TSRFactory
+from tsr.tsr import TSR, TSRChain
 
 @TSRFactory('herb', 'block_bin', 'point_on')
 def point_on(robot, block_bin, manip=None, padding=0.04):

--- a/src/herbpy/tsr/box.py
+++ b/src/herbpy/tsr/box.py
@@ -1,7 +1,8 @@
 import numpy
-import prpy.tsr
+from tsr.tsrlibrary import TSRFactory
+from tsr.tsr import TSR, TSRChain
 
-@prpy.tsr.tsrlibrary.TSRFactory('herb', 'box', 'stamp')
+@TSRFactory('herb', 'box', 'stamp')
 def box_stamp(robot, box, manip=None):
 
     '''
@@ -35,8 +36,8 @@ def box_stamp(robot, box, manip=None):
     Bw = numpy.zeros((6, 2))
     Bw[5, :] = [-numpy.pi, numpy.pi]  # Allow any orientation
 
-    grasp_tsr = prpy.tsr.TSR(T0_w=T0_w, Tw_e=Tw_e, Bw=Bw, manip=manip_idx)
-    grasp_chain = prpy.tsr.TSRChain(sample_start=False, sample_goal=True,
+    grasp_tsr = TSR(T0_w=T0_w, Tw_e=Tw_e, Bw=Bw, manip=manip_idx)
+    grasp_chain = TSRChain(sample_start=False, sample_goal=True,
                                     constrain=False, TSR=grasp_tsr)
 
     return [grasp_chain]

--- a/src/herbpy/tsr/fuze.py
+++ b/src/herbpy/tsr/fuze.py
@@ -1,4 +1,4 @@
-from prpy.tsr.tsrlibrary import TSRFactory
+from tsr.tsrlibrary import TSRFactory
 
 @TSRFactory('herb', 'fuze_bottle', 'grasp')
 def fuze_grasp(robot, fuze, manip=None, **kw_args):
@@ -71,7 +71,7 @@ def fuze_transport(robot, fuze, manip=None, roll_epsilon=0.2, pitch_epsilon=0.2,
     @param yaw_epsilon The amount to let the object yaw during
                          transport (object frame)
     """
-    from prpy.tsr.generic import transport_upright_tsr
+    from tsr.generic import transport_upright_tsr
     return transport_upright_tsr(robot, fuze, manip=manip,
                                  roll_epsilon=roll_epsilon,
                                  pitch_epsilon=pitch_epsilon,

--- a/src/herbpy/tsr/generic.py
+++ b/src/herbpy/tsr/generic.py
@@ -1,6 +1,6 @@
 import numpy, prpy
-from prpy.tsr.tsrlibrary import TSRFactory
-from prpy.tsr.tsr import TSR, TSRChain
+from tsr.tsrlibrary import TSRFactory
+from tsr.tsr import TSR, TSRChain
 from prpy.util import GetManipulatorIndex
 
 @TSRFactory('herb', None, 'point')

--- a/src/herbpy/tsr/glass.py
+++ b/src/herbpy/tsr/glass.py
@@ -1,4 +1,4 @@
-from prpy.tsr.tsrlibrary import TSRFactory
+from tsr.tsrlibrary import TSRFactory
 
 @TSRFactory('herb', 'plastic_glass', 'grasp')
 def glass_grasp(robot, glass, manip=None, yaw_range=None, **kw_args):

--- a/src/herbpy/tsr/pill_bottle.py
+++ b/src/herbpy/tsr/pill_bottle.py
@@ -1,6 +1,6 @@
 import numpy
-from prpy.tsr.tsrlibrary import TSRFactory
-from prpy.tsr.tsr import TSR, TSRChain
+from tsr.tsrlibrary import TSRFactory
+from tsr.tsr import TSR, TSRChain
 
 @TSRFactory('herb', 'pill_bottle', 'grasp')
 def pills_grasp(robot, pills, manip=None, **kw_args):

--- a/src/herbpy/tsr/pitcher.py
+++ b/src/herbpy/tsr/pitcher.py
@@ -1,7 +1,6 @@
 import numpy, openravepy
-import prpy.tsr
-from prpy.tsr.tsrlibrary import TSRFactory
-from prpy.tsr.tsr import TSR, TSRChain
+from tsr.tsrlibrary import TSRFactory
+from tsr.tsr import TSR, TSRChain
 
 @TSRFactory('herb', 'rubbermaid_ice_guard_pitcher', 'push_grasp')
 def pitcher_grasp(robot, pitcher, push_distance=0.1, manip=None, **kw_args):
@@ -46,9 +45,9 @@ def pitcher_grasp(robot, pitcher, push_distance=0.1, manip=None, **kw_args):
     Bw = numpy.zeros((6, 2))
     Bw[2, :] = [-0.01, 0.01]  # Allow a little vertical movement
 
-    grasp_tsr = prpy.tsr.TSR(T0_w=T0_w, Tw_e=ee_in_pitcher,
+    grasp_tsr = TSR(T0_w=T0_w, Tw_e=ee_in_pitcher,
                              Bw=Bw, manip=manip_idx)
-    grasp_chain = prpy.tsr.TSRChain(sample_start=False, sample_goal=True,
+    grasp_chain = TSRChain(sample_start=False, sample_goal=True,
                                     constrain=False, TSR=grasp_tsr)
 
     return [grasp_chain]

--- a/src/herbpy/tsr/pop_tarts.py
+++ b/src/herbpy/tsr/pop_tarts.py
@@ -1,4 +1,4 @@
-from prpy.tsr.tsrlibrary import TSRFactory
+from tsr.tsrlibrary import TSRFactory
 
 @TSRFactory('herb', 'pop_tarts', 'grasp')
 def poptarts_grasp(robot, pop_tarts, manip=None, **kw_args):

--- a/src/herbpy/tsr/table.py
+++ b/src/herbpy/tsr/table.py
@@ -1,6 +1,6 @@
 import numpy
-from prpy.tsr.tsrlibrary import TSRFactory
-from prpy.tsr.tsr import TSR, TSRChain
+from tsr.tsrlibrary import TSRFactory
+from tsr.tsr import TSR, TSRChain
 
 @TSRFactory('herb', 'table', 'point_on')
 def point_on(robot, table, manip=None, padding=0, **kwargs):


### PR DESCRIPTION
All the HERB tsr files have their imports corrected so that `rosrun herbpy console.py` now loads.
Please run other herbpy tests as well. The merge should be a 3-way merge of:

- `tsr` to include `remove_or_deps`
- `prpy` to include `split_tsr`
- `herbpy` to include this branch